### PR TITLE
fixes issue #9

### DIFF
--- a/stylesheets/minimap.less
+++ b/stylesheets/minimap.less
@@ -13,7 +13,9 @@
 }
 
 .minimap {
-  position: fixed;
+  position: absolute;
+  margin-right: 15px;
+  right: 0;
   left: inherit;
   opacity: .77;
   width: 125px;


### PR DESCRIPTION
Moving from fixed positioning to absolute solves problem of minimap disappearing behind file browser panel when arranged to the right.

```
right: 0; 
```

can remain to help with window resizes etc.
