### PR TITLE
Fix broken minimap activation on non editor view

### DIFF
--- a/lib/minimap-view.coffee
+++ b/lib/minimap-view.coffee
@@ -81,10 +81,10 @@ class MinimapView extends View
 
   storeActiveEditor: ->
     @editorView = @getEditorView()
+    @editor = @editorView.getEditor()
 
     @unsubscribeFromEditor()
 
-    @editor = @editorView.getEditor()
     @scrollView = @editorView.scrollView
     @scrollViewLines = @scrollView.find('.lines')
 
@@ -98,11 +98,18 @@ class MinimapView extends View
     @subscribe @editor, 'scroll-top-changed.minimap', @updateScroll
     #@subscribe @editor, 'scroll-left-changed.minimap', @updateScroll
 
+  # See /Applications/Atom.app/Contents/Resources/app/src/pane-view.js#349
+  # pane-view's private api
+  # `paneView.activeView` and `paneView.activeItem`
   getEditorView: -> @paneView.viewForItem(@activeItem)
 
   getEditorViewClientRect: -> @scrollView[0].getBoundingClientRect()
 
   getScrollViewClientRect: -> @scrollViewLines[0].getBoundingClientRect()
+
+  # See https://atom.io/docs/api/v0.83.0/api/classes/Pane.html#getActiveEditor-instance
+  # Returns an Editor if the pane item is an Editor, or null otherwise.
+  getEditor: -> @paneView.model.getActiveEditor()
 
   setMinimapEditorView: ->
     # update minimap-editor
@@ -155,7 +162,7 @@ class MinimapView extends View
 
   onActiveItemChanged: (item) =>
     # Fix called twice when opening minimap!
-    return if @activeItem == item
+    return if item is @activeItem
     @activeItem = item
 
     if @activeTabSupportMinimap()
@@ -217,9 +224,7 @@ class MinimapView extends View
   # OTHER PRIVATE METHODS
 
   activeTabSupportMinimap: ->
-    editorView = @getEditorView()
-
-    editorView? and editorView.hasClass('editor')
+    @getEditor()
 
   scale: (x=1,y=1) -> "scale(#{x}, #{y}) "
   translateY: (y=0) -> "translate3d(0, #{y}px, 0)"


### PR DESCRIPTION
- improve `activeTabSupportMinimap`
- fix does not update editor first, but unsubscribe directly
