### PR TITLE
remove "Enable minimap" from context menu

### DIFF
--- a/menus/minimap.cson
+++ b/menus/minimap.cson
@@ -1,8 +1,4 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
-'context-menu':
-  '.overlayer':
-      'Enable minimap': 'minimap:toggle'
-
 'menu': [
   {
     'label': 'Packages'


### PR DESCRIPTION
We have a shotcut and the `Packages` menu. I think adding "enable minimap" to the context menu too is too much.
