### PR TITLE
🐎 Removes forced hardware acceleration on minimap

### DIFF
--- a/lib/minimap-view.coffee
+++ b/lib/minimap-view.coffee
@@ -259,6 +259,6 @@ class MinimapView extends View
   # OTHER PRIVATE METHODS
 
   scale: (x=1,y=1) -> "scale(#{x}, #{y}) "
-  translate: (x=0,y=0) -> "translate3d(#{x}px, #{y}px, 0)"
+  translate: (x=0,y=0) -> "translate(#{x}px, #{y}px)"
   transform: (el, transform) ->
     el.style.webkitTransform = el.style.transform = transform

--- a/stylesheets/minimap.less
+++ b/stylesheets/minimap.less
@@ -47,7 +47,7 @@
   bottom: 0;
   overflow: hidden;
   box-sizing: border-box;
-  .accelerated;
+  // .accelerated;
 
   .editor {
     padding: 0 !important;
@@ -59,6 +59,7 @@
 
   .line {
     opacity: .6;
+    .accelerated;
   }
 
   .minimap-scroller {
@@ -69,7 +70,7 @@
     min-height: 2px;
     z-index: 10;
     background: @background-color-selected;
-    .accelerated;
+    // .accelerated;
 
     &.visible {
       display: block;
@@ -87,7 +88,7 @@
     width: 100%;
     background-color: #888;
     opacity: .2;
-    .accelerated;
+    // .accelerated;
   }
 
   .minimap-editor {
@@ -96,7 +97,7 @@
     width: 100%;
     .accelerated;
     .scroll-view {
-      .accelerated;
+      // .accelerated;
     }
   }
 


### PR DESCRIPTION
With the new view-aware rendering of the minimap a lot of time is now
passed refreshing the gpu textures when new lines are added/removed
during scroll. Using the profiling tools confirm that.

This commit includes removal of all the `accelerated` class inclusion
in container node and put it instead on lines.
It also includes the change of the translate method to generate
`translate` transformation instead of `translate3d`.

This is an experiment, on my MBA I can feel that scrolling is a little bit smoother (less lag when the minimap is updated), but I can be wrong. The profiler seems confirming that a lot more time is passed in updating the wrapper element when scroll trigger a changes of the rendered lines.
I'll need more feedback to definitely consider these changes as a real improvement.
