### PR TITLE
Update minimap whenever theme is reloaded

### DIFF
--- a/lib/minimap-view.coffee
+++ b/lib/minimap-view.coffee
@@ -125,6 +125,11 @@ class MinimapView extends View
     config = childList: true
     @observer.observe @paneView.element, config
 
+    # Update the minimap whenever theme is reloaded
+    @subscriptions.add atom.themes.onDidReloadAll =>
+      @adjustTopPosition()
+      @updateMinimapView()
+
     # The resize:end event is dispatched at the end of an animated resize
     # to not flood the cpu with updates.
     @subscribe $(window), 'resize:end', @onScrollViewResized


### PR DESCRIPTION
Fixes the case where the minimap is positioned incorrectly if you have something in your `styles.less` that alters the tab bar height. It also fixes a similar possible case where changing the theme would do the same.

I wasn't 100% sure what methods I should be calling to update the minimap (there are quite a few) but this works for me.
