### PR TITLE
Remove padding to allow text flow under minimap

### DIFF
--- a/stylesheets/minimap.less
+++ b/stylesheets/minimap.less
@@ -3,7 +3,7 @@
 
 .pane.with-minimap {
   :not(.minimap-editor):not(.mini) > .editor-contents {
-    padding-right: 10%;
+    padding-right: 0%;
   }
   .vertical-scrollbar {
     right: 10%;


### PR DESCRIPTION
![clipboard01](https://cloud.githubusercontent.com/assets/5605624/4957267/d89328d6-66a2-11e4-8796-2e7a40f814fa.png)
![clipboard02](https://cloud.githubusercontent.com/assets/5605624/4957268/d89ab736-66a2-11e4-9f15-b42cc8bdf529.png)
