### PR TITLE
Implemented middle click to jump-to-location

### DIFF
--- a/lib/minimap-element.coffee
+++ b/lib/minimap-element.coffee
@@ -455,6 +455,9 @@ class MinimapElement extends HTMLElement
       @leftMousePressedOverCanvas(e)
     else if e.which is 2
       @middleMousePressedOverCanvas(e)
+      # @requestForcedUpdate()
+      {top, height} = @visibleArea.getBoundingClientRect()
+      @startDrag({which: 2, pageY: top + height/2}) # ugly hack
     else return
 
   leftMousePressedOverCanvas: ({pageY, target}) ->
@@ -506,10 +509,10 @@ class MinimapElement extends HTMLElement
   #
   # event - The {Event} object.
   startDrag: ({which, pageY}) ->
-    if which is 2
-      @mousePressedOverCanvas({which, pageY})
+    # if which is 2
+    #   @middleMousePressedOverCanvas({pageY})
 
-    return if which isnt 1
+    return if which isnt 1 and which isnt 2
     {top} = @visibleArea.getBoundingClientRect()
     {top: offsetTop} = @getBoundingClientRect()
 
@@ -538,7 +541,7 @@ class MinimapElement extends HTMLElement
   #           offsetTop - The {MinimapElement} offset at the moment of the
   #                       drag start.
   drag: (e, initial) ->
-    return if e.which isnt 1
+    return if e.which isnt 1 and e.which isnt 2
     y = e.pageY - initial.offsetTop - initial.dragOffset
 
     ratio = y / (@minimap.getVisibleHeight() - @minimap.getTextEditorScaledHeight())

--- a/lib/minimap-element.coffee
+++ b/lib/minimap-element.coffee
@@ -450,9 +450,14 @@ class MinimapElement extends HTMLElement
   # {MinimapElement} canvas.
   #
   # event - The {Event} object.
-  mousePressedOverCanvas: ({which, pageY, target}) ->
-    return if which isnt 1
+  mousePressedOverCanvas: (e) ->
+    if e.which is 1
+      @leftMousePressedOverCanvas(e)
+    else if e.which is 2
+      @middleMousePressedOverCanvas(e)
+    else return
 
+  leftMousePressedOverCanvas: ({pageY, target}) ->
     y = pageY - target.getBoundingClientRect().top
     row = Math.floor(y / @minimap.getLineHeight()) + @minimap.getFirstVisibleScreenRow()
 
@@ -468,6 +473,16 @@ class MinimapElement extends HTMLElement
       @animate(from: from, to: to, duration: duration, step: step)
     else
       textEditor.setScrollTop(scrollTop)
+
+  middleMousePressedOverCanvas: ({pageY}) ->
+    {top: offsetTop} = @getBoundingClientRect()
+    y = pageY - offsetTop - @minimap.getTextEditorScaledHeight()/2
+
+    ratio = y /
+      (@minimap.getVisibleHeight() - @minimap.getTextEditorScaledHeight())
+
+    @minimap.textEditor.setScrollTop(
+      ratio * @minimap.getTextEditorMaxScrollTop())
 
   # Internal: A method that relays the `mousewheel` events received by
   # the {MinimapElement} to the {TextEditorElement}.
@@ -491,6 +506,9 @@ class MinimapElement extends HTMLElement
   #
   # event - The {Event} object.
   startDrag: ({which, pageY}) ->
+    if which is 2
+      @mousePressedOverCanvas({which, pageY})
+
     return if which isnt 1
     {top} = @visibleArea.getBoundingClientRect()
     {top: offsetTop} = @getBoundingClientRect()

--- a/spec/helpers/events.coffee
+++ b/spec/helpers/events.coffee
@@ -14,8 +14,7 @@ mouseEvent = (type, properties) ->
     shiftKey: false
     metaKey: false
     button: 0
-    relatedTarget: `undefined`
-    which: 1
+    relatedTarget: undefined
   }
 
   properties[k] = v for k,v of defaults when not properties[k]?
@@ -29,14 +28,15 @@ objectCenterCoordinates = (obj) ->
 module.exports = {objectCenterCoordinates, mouseEvent}
 
 ['mousedown', 'mousemove', 'mouseup', 'click'].forEach (key) ->
-  module.exports[key] = (obj, {x, y, cx, cy, which}={}) ->
+  module.exports[key] = (obj, {x, y, cx, cy, btn} = {}) ->
     {x,y} = objectCenterCoordinates(obj) unless x? and y?
 
     unless cx? and cy?
       cx = x
       cy = y
 
-    obj.dispatchEvent(mouseEvent key, {pageX: x, pageY: y, clientX: cx, clientY: cy, which})
+    obj.dispatchEvent(mouseEvent key, {
+      pageX: x, pageY: y, clientX: cx, clientY: cy, button: btn})
 
 module.exports.mousewheel = (obj, deltaX=0, deltaY=0) ->
   obj.dispatchEvent(mouseEvent 'mousewheel', {deltaX, deltaY})

--- a/spec/minimap-element-spec.coffee
+++ b/spec/minimap-element-spec.coffee
@@ -309,10 +309,8 @@ describe 'MinimapElement', ->
         [canvas, visibleArea, originalLeft, maxScroll] = []
 
         beforeEach ->
-          canvas = minimapElement.canvas
-          visibleArea = minimapElement.visibleArea
-          {left} = visibleArea.getBoundingClientRect()
-          [originalLeft] = [left]
+          {canvas, visibleArea} = minimapElement
+          {left: originalLeft} = visibleArea.getBoundingClientRect()
           maxScroll = minimap.getTextEditorMaxScrollTop()
 
         it 'scrolls to the top using the middle mouse button', ->
@@ -343,7 +341,7 @@ describe 'MinimapElement', ->
           [scrollTo, scrollRatio] = []
 
           beforeEach ->
-            scrollTo = 100 # pixels
+            scrollTo = 101 # pixels
             scrollRatio = (scrollTo - minimap.getTextEditorScaledHeight()/2) /
               (minimap.getVisibleHeight() - minimap.getTextEditorScaledHeight())
             scrollRatio = Math.max(0, scrollRatio)
@@ -361,8 +359,7 @@ describe 'MinimapElement', ->
             [originalTop] = []
 
             beforeEach ->
-              {top} = visibleArea.getBoundingClientRect()
-              originalTop = top
+              {top: originalTop} = visibleArea.getBoundingClientRect()
               mousemove(visibleArea, x: originalLeft + 1, y: scrollTo + 40)
 
               nextAnimationFrame()
@@ -418,11 +415,10 @@ describe 'MinimapElement', ->
 
         beforeEach ->
           visibleArea = minimapElement.visibleArea
-          {top, left} = visibleArea.getBoundingClientRect()
-          originalTop = top
+          {top: originalTop, left} = visibleArea.getBoundingClientRect()
 
-          mousedown(visibleArea, x: left + 10, y: top + 10)
-          mousemove(visibleArea, x: left + 10, y: top + 50)
+          mousedown(visibleArea, x: left + 10, y: originalTop + 10)
+          mousemove(visibleArea, x: left + 10, y: originalTop + 50)
 
           nextAnimationFrame()
 

--- a/spec/minimap-element-spec.coffee
+++ b/spec/minimap-element-spec.coffee
@@ -305,6 +305,52 @@ describe 'MinimapElement', ->
         it 'relays the events to the editor view', ->
           expect(editorElement.component.presenter.setScrollTop).toHaveBeenCalled()
 
+      describe 'middle clicking the minimap', ->
+        [canvas, visibleArea, originalTop, originalLeft, maxScroll] = []
+
+        beforeEach ->
+          canvas = minimapElement.canvas
+          visibleArea = minimapElement.visibleArea
+          {top, left} = visibleArea.getBoundingClientRect()
+          [originalTop, originalLeft] = [top, left]
+          maxScroll = minimap.getTextEditorMaxScrollTop()
+
+        it 'scrolls to the top using the middle mouse button', ->
+          mousedown(canvas, x: originalLeft + 1, y: 0, btn: 1)
+          expect(editor.getScrollTop()).toEqual(0)
+
+        describe 'scrolling to the middle using the middle mouse button', ->
+          canvasMidY = undefined
+
+          beforeEach ->
+            editorMidY = editor.getHeight() / 2.0
+            {top, height} = canvas.getBoundingClientRect()
+            canvasMidY = top + (height / 2.0)
+            actualMidY = Math.min(canvasMidY, editorMidY)
+            mousedown(canvas, x: originalLeft + 1, y: actualMidY, btn: 1)
+
+          it 'scrolls the editor to the middle', ->
+            middleScrollTop = Math.round((maxScroll) / 2.0)
+            expect(editor.getScrollTop()).toEqual(middleScrollTop)
+
+          it 'updates the visible area to be centered', ->
+            nextAnimationFrame()
+            {top, height} = visibleArea.getBoundingClientRect()
+            visibleCenterY = top + (height / 2)
+            expect(visibleCenterY).toBeCloseTo(canvasMidY, 0)
+
+        it 'scrolls the editor to an arbitrary location', ->
+          scrollTo = 100 # pixels
+          scrollRatio = (scrollTo - minimap.getTextEditorScaledHeight()/2) /
+            (minimap.getVisibleHeight() - minimap.getTextEditorScaledHeight())
+          scrollRatio = Math.max(0, scrollRatio)
+          scrollRatio = Math.min(1, scrollRatio)
+
+          mousedown(canvas, x: originalLeft + 1, y: scrollTo, btn: 1)
+
+          expectedScroll = maxScroll * scrollRatio
+          expect(editor.getScrollTop()).toBeCloseTo(expectedScroll, 0)
+
       describe 'pressing the mouse on the minimap canvas (without scroll animation)', ->
         beforeEach ->
           t = 0


### PR DESCRIPTION
Prerequisite for #290. 

This only covers the middle click equivalent to clicking on the minimap (point 1 in the original comment of #290). Dragging is not yet implemented. 

In the current implementation, middle clicking (even on this "visibleArea") centers the visible area to that destination. This may or may not prove awkward after dragging is implemented. I thought it would be more consistent this way. However, it looks like most scroll bar implementations behave the same way if they're left clicked or middle clicked (if started dragging from the bar itself), so I may revisit this while implementing dragging.