### PR TITLE
Fix for #314 - end drag when alttabed away from atom

### DIFF
--- a/lib/minimap-element.coffee
+++ b/lib/minimap-element.coffee
@@ -505,6 +505,7 @@ class MinimapElement extends HTMLElement
     document.body.addEventListener('mousemove', mousemoveHandler)
     document.body.addEventListener('mouseup', mouseupHandler)
     document.body.addEventListener('mouseleave', mouseupHandler)
+    document.body.onblur = mouseupHandler
 
     @dragSubscription = new Disposable ->
       document.body.removeEventListener('mousemove', mousemoveHandler)


### PR DESCRIPTION
This fixes #314, with some reservations that may or may not matter:

1. This fix doesn't let us comment out the event handlers on `mouseleave`
2. I'm not sure if the `onblur` event should be on document.body or on the minimap element
3. Not sure how to write specs for this :)
