### PR TITLE
Fix Decoration @displayBuffer argument

### DIFF
--- a/lib/mixins/decoration-management.coffee
+++ b/lib/mixins/decoration-management.coffee
@@ -200,7 +200,7 @@ class DecorationManagement extends Mixin
 
       @emitRangeChanges({start, end})
 
-    decoration = new Decoration(marker, this, decorationParams)
+    decoration = new Decoration(marker, this.textEditor.displayBuffer, decorationParams)
     @decorationsByMarkerId[marker.id] ?= []
     @decorationsByMarkerId[marker.id].push(decoration)
     @decorationsById[decoration.id] = decoration


### PR DESCRIPTION
This Pull-Request fix #335

@displayBuffer arg is actually used from atom/atom@b80c480d863e8ac9a8f98659445741f4b1684fe1
