### PR TITLE
support devicePixelRation option

### DIFF
--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -714,6 +714,7 @@ export default class MinimapElement {
     let minimap = this.minimap
     minimap.enableCache()
 
+    const devicePixelRatio = this.minimap.getDevicePixelRatio()
     let visibleAreaLeft = minimap.getTextEditorScaledScrollLeft()
     let visibleAreaTop = minimap.getTextEditorScaledScrollTop() - minimap.getScrollTop()
     let visibleWidth = Math.min(this.canvas.width / devicePixelRatio, this.width)
@@ -847,6 +848,7 @@ export default class MinimapElement {
   measureHeightAndWidth (visibilityChanged, forceUpdate = true) {
     if (!this.minimap) { return }
 
+    const devicePixelRatio = this.minimap.getDevicePixelRatio()
     let wasResized = this.width !== this.clientWidth || this.height !== this.clientHeight
 
     this.height = this.clientHeight

--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -142,6 +142,14 @@ export default class Minimap {
      */
     this.configInterline = null
     /**
+     * The devicePixelRatio of the current device.
+     *
+     * @type {number}
+     * @access private
+     */
+    this.devicePixelRatio = Math.floor(devicePixelRatio)
+    /**
+    /**
      * A boolean value to store whether this Minimap have been destroyed or not.
      *
      * @type {boolean}
@@ -654,6 +662,15 @@ export default class Minimap {
   }
 
   /**
+   * Returns the devicePixelRatio of devicePixelRatio in the Minimap in pixels.
+   *
+   * @return {number} the devicePixelRatio in the Minimap
+   */
+  getDevicePixelRatio() {
+    return this.devicePixelRatio
+  }
+
+  /**
    * Returns the index of the first visible row in the Minimap.
    *
    * @return {number} the index of the first visible row
@@ -769,4 +786,5 @@ export default class Minimap {
    * @access private
    */
   clearCache () { this.adapter.clearCache() }
+
 }

--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -191,6 +191,7 @@ export default class CanvasDrawer extends Mixin {
   drawLines (context, firstRow, lastRow, offsetRow) {
     if (firstRow > lastRow) { return }
 
+    const devicePixelRatio = this.minimap.getDevicePixelRatio()
     let lines = this.getTextEditor().tokenizedLinesForScreenRows(firstRow, lastRow)
     let lineHeight = this.minimap.getLineHeight() * devicePixelRatio
     let charHeight = this.minimap.getCharHeight() * devicePixelRatio
@@ -471,6 +472,7 @@ export default class CanvasDrawer extends Mixin {
    * @access private
    */
   copyBitmapPart (context, bitmapCanvas, srcRow, destRow, rowCount) {
+    const devicePixelRatio = this.minimap.getDevicePixelRatio()
     let lineHeight = this.minimap.getLineHeight() * devicePixelRatio
 
     context.drawImage(


### PR DESCRIPTION
I have tow devices(RMBP 13 + DELL U2412M Display).
The  DELL U2412M Display is not the retinal display, so the `devicePixelRation = 1`.

If there is a devicePixelRation option for our convenience.
Sometimes we will move the window to another display.