### PR TITLE
add Minimap#getDevicePixelRatio and flooring the devicePixelRatio

### DIFF
--- a/lib/config-schema.json
+++ b/lib/config-schema.json
@@ -35,6 +35,11 @@
     "default":true,
     "description":"If this option is enabled and Soft Wrap is checked then the Minimap max width is set to the Preferred Line Length value."
   },
+  "devicePixelRatioRounding":{
+    "type":"boolean",
+    "default":true,
+    "description":"Toggles the rounding of the devicePixelRatio in the minimap."
+  },
   "charWidth":{
     "type":"number",
     "default":1,

--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -714,6 +714,7 @@ export default class MinimapElement {
     let minimap = this.minimap
     minimap.enableCache()
 
+    const devicePixelRatio = this.minimap.getDevicePixelRatio()
     let visibleAreaLeft = minimap.getTextEditorScaledScrollLeft()
     let visibleAreaTop = minimap.getTextEditorScaledScrollTop() - minimap.getScrollTop()
     let visibleWidth = Math.min(this.canvas.width / devicePixelRatio, this.width)
@@ -847,6 +848,7 @@ export default class MinimapElement {
   measureHeightAndWidth (visibilityChanged, forceUpdate = true) {
     if (!this.minimap) { return }
 
+    const devicePixelRatio = this.minimap.getDevicePixelRatio()
     let wasResized = this.width !== this.clientWidth || this.height !== this.clientHeight
 
     this.height = this.clientHeight

--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -142,6 +142,23 @@ export default class Minimap {
      */
     this.configInterline = null
     /**
+     * The devicePixelRatioRounding of the current Minimap, will be
+     * `undefined` unless `setDevicePixelRatioRounding` is called.
+     *
+     * @type {boolean}
+     * @access private
+     */
+    this.devicePixelRatioRounding = null
+    /**
+     * The devicePixelRatioRounding from the package's configuration.
+     * Will be overriden by the instance value.
+     *
+     * @type {boolean}
+     * @access private
+     */
+    this.configDevicePixelRatioRounding = null
+    /**
+    /**
      * A boolean value to store whether this Minimap have been destroyed or not.
      *
      * @type {boolean}
@@ -194,6 +211,14 @@ export default class Minimap {
       this.configInterline = configInterline
       this.emitter.emit('did-change-config')
     }))
+    // cdprr is shorthand for configDevicePixelRatioRounding
+    subs.add(atom.config.observe(
+      'minimap.devicePixelRatioRounding',
+      (cdprr) => {
+        this.configDevicePixelRatioRounding = cdprr
+        this.emitter.emit('did-change-config')
+      }
+    ))
 
     subs.add(this.adapter.onDidChangeScrollTop(() => {
       if (!this.standAlone) {
@@ -654,6 +679,44 @@ export default class Minimap {
   }
 
   /**
+   * Returns the status of devicePixelRatioRounding in the Minimap.
+   *
+   * @return {boolean} the devicePixelRatioRounding status in the Minimap
+   */
+  getDevicePixelRatioRounding () {
+    if (this.devicePixelRatioRounding != null) {
+      return this.devicePixelRatioRounding
+    } else {
+      return this.configDevicePixelRatioRounding
+    }
+  }
+
+  /**
+   * Sets the devicePixelRatioRounding status for this Minimap.
+   * This value will override the value from the config for this instance only.
+   * A `did-change-config` event is dispatched.
+   *
+   * @param {booean} devicePixelRatioRoundingin the new status of
+   *    devicePixelRatioRounding in the Minimap
+   * @emits {did-change-config} when the value is changed
+   */
+  setDevicePixelRatioRounding (devicePixelRatioRounding) {
+    this.devicePixelRatioRounding = devicePixelRatioRounding
+    this.emitter.emit('did-change-config')
+  }
+
+  /**
+   * Returns the devicePixelRatio in the Minimap in pixels.
+   *
+   * @return {number} the devicePixelRatio in the Minimap
+   */
+  getDevicePixelRatio() {
+    return this.getDevicePixelRatioRounding()
+      ? Math.floor(devicePixelRatio)
+      : devicePixelRatio
+  }
+
+  /**
    * Returns the index of the first visible row in the Minimap.
    *
    * @return {number} the index of the first visible row
@@ -769,4 +832,5 @@ export default class Minimap {
    * @access private
    */
   clearCache () { this.adapter.clearCache() }
+
 }

--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -191,6 +191,7 @@ export default class CanvasDrawer extends Mixin {
   drawLines (context, firstRow, lastRow, offsetRow) {
     if (firstRow > lastRow) { return }
 
+    const devicePixelRatio = this.minimap.getDevicePixelRatio()
     let lines = this.getTextEditor().tokenizedLinesForScreenRows(firstRow, lastRow)
     let lineHeight = this.minimap.getLineHeight() * devicePixelRatio
     let charHeight = this.minimap.getCharHeight() * devicePixelRatio
@@ -471,6 +472,7 @@ export default class CanvasDrawer extends Mixin {
    * @access private
    */
   copyBitmapPart (context, bitmapCanvas, srcRow, destRow, rowCount) {
+    const devicePixelRatio = this.minimap.getDevicePixelRatio()
     let lineHeight = this.minimap.getLineHeight() * devicePixelRatio
 
     context.drawImage(

--- a/spec/minimap-element-spec.js
+++ b/spec/minimap-element-spec.js
@@ -23,7 +23,7 @@ function isVisible (node) {
   return node.offsetWidth > 0 || node.offsetHeight > 0
 }
 
-// Modify the global `devicePixelRatio` letiable.
+// Modify the global `devicePixelRatio` litiable.
 // window.devicePixelRatio = 2
 
 function sleep (duration) {

--- a/spec/minimap-spec.js
+++ b/spec/minimap-spec.js
@@ -591,4 +591,22 @@ describe('Stand alone minimap', () => {
 
     expect(changeSpy.callCount).toEqual(3)
   })
+
+  it('returns the rounding number of devicePixelRatio', () => {
+    devicePixelRatio = 1.25
+
+    minimap.setDevicePixelRatioRounding(true)
+
+    expect(minimap.getDevicePixelRatioRounding()).toEqual(true)
+    expect(minimap.getDevicePixelRatio()).toEqual(1)
+  })
+
+  it('prevents the rounding number of devicePixelRatio', () => {
+    devicePixelRatio = 1.25
+
+    minimap.setDevicePixelRatioRounding(false)
+
+    expect(minimap.getDevicePixelRatioRounding()).toEqual(false)
+    expect(minimap.getDevicePixelRatio()).toEqual(1.25)
+  })
 })


### PR DESCRIPTION
@abe33 

Should it need an option for `preventDevicePixelRatioRounding`?