### PR TITLE
Update settings icon position

### DIFF
--- a/styles/minimap.less
+++ b/styles/minimap.less
@@ -93,7 +93,7 @@ atom-text-editor::shadow, atom-text-editor, html {
         width: 24px;
         height: 24px;
         display: block;
-        right: 4px;
+        right: 8px;
         transition: opacity 0.4s;
 
         &:before {


### PR DESCRIPTION
When the minimap is on right with absolute-mode the settings icon is  kind of blocked by the atom scrollbar.