### PR TITLE
Start using new DisplayLayer APIs

### DIFF
--- a/lib/adapters/legacy-adapter.js
+++ b/lib/adapters/legacy-adapter.js
@@ -63,7 +63,7 @@ export default class LegacyAdater {
     if (this.maxScrollTopCache != null && this.useCache) {
       return this.maxScrollTopCache
     }
-    var maxScrollTop = this.textEditor.displayBuffer.getMaxScrollTop()
+    var maxScrollTop = this.textEditor.getMaxScrollTop()
     var lineHeight = this.textEditor.getLineHeightInPixels()
 
     if (this.scrollPastEnd) {

--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -232,7 +232,8 @@ export default class Minimap {
     resulting in extra lines appearing at the end of the minimap.
     Forcing a whole repaint to fix that bug is suboptimal but works.
     */
-    subs.add(this.textEditor.tokenizedBuffer.onDidTokenize(() => {
+    let tokenizedBuffer = this.textEditor.tokenizedBuffer ? this.textEditor.tokenizedBuffer : this.textEditor.displayBuffer.tokenizedBuffer
+    subs.add(tokenizedBuffer.onDidTokenize(() => {
       this.emitter.emit('did-change-config')
     }))
   }

--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -232,7 +232,7 @@ export default class Minimap {
     resulting in extra lines appearing at the end of the minimap.
     Forcing a whole repaint to fix that bug is suboptimal but works.
     */
-    subs.add(this.textEditor.displayBuffer.onDidTokenize(() => {
+    subs.add(this.textEditor.tokenizedBuffer.onDidTokenize(() => {
       this.emitter.emit('did-change-config')
     }))
   }

--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -300,7 +300,7 @@ export default class CanvasDrawer extends Mixin {
     for (let i = 0, len = ranges.length; i < len; i++) {
       const range = ranges[i]
 
-      method.call(this, currentRow, range.start - 1, currentRow - firstRow)
+      method.call(this, currentRow, range.start, currentRow - firstRow)
 
       currentRow = range.end
     }
@@ -477,6 +477,7 @@ export default class CanvasDrawer extends Mixin {
     let y = offsetRow * lineHeight
     for (let tokens of this.tokenLinesForScreenRows(firstRow, lastRow)) {
       let x = 0
+      context.clearRect(x, y, canvasWidth, lineHeight)
       for (let token of tokens) {
         if (/^\s+$/.test(token.value)) {
           x += token.value.length * charWidth
@@ -592,6 +593,11 @@ export default class CanvasDrawer extends Mixin {
    */
   drawDecorations (screenRow, decorations, renderData, types) {
     let decorationsToRender = []
+
+    renderData.context.clearRect(
+      0, renderData.yRow,
+      renderData.canvasWidth, renderData.lineHeight
+    )
 
     for (let i in types) {
       decorationsToRender = decorationsToRender.concat(

--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -405,7 +405,7 @@ export default class CanvasDrawer extends Mixin {
   tokenLinesForScreenRows (startRow, endRow) {
     const editor = this.getTextEditor()
     let tokenLines = []
-    if (typeof editor.tokenizedLinesForScreenRows === "function") {
+    if (typeof editor.tokenizedLinesForScreenRows === 'function') {
       for (let tokenizedLine of editor.tokenizedLinesForScreenRows(startRow, endRow)) {
         tokenLines.push(tokenizedLine.tokens)
       }

--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -402,6 +402,14 @@ export default class CanvasDrawer extends Mixin {
     renderData.context.fill()
   }
 
+  /**
+   * Returns an array of tokens by line.
+   *
+   * @param  {number} startRow The start row
+   * @param  {number} endRow The end row
+   * @return {Array<Array>} An array of tokens by line
+   * @access private
+   */
   tokenLinesForScreenRows (startRow, endRow) {
     const editor = this.getTextEditor()
     let tokenLines = []
@@ -503,6 +511,15 @@ export default class CanvasDrawer extends Mixin {
     return new RegExp(_.escapeRegExp(regexp.slice(0, -1)), 'g')
   }
 
+  /**
+   * Returns the regexp to replace invisibles substitution characters
+   * in editor lines.
+   *
+   * @param  {Object} line the tokenized line
+   * @return {RegExp} the regular expression to match invisible characters
+   * @deprecated Is used only to support Atom version before display layer API
+   * @access private
+   */
   getInvisibleRegExpForLine (line) {
     if ((line != null) && (line.invisibles != null)) {
       const invisibles = []

--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -401,6 +401,36 @@ export default class CanvasDrawer extends Mixin {
 
     renderData.context.fill()
   }
+
+  tokenLinesForScreenRows (startRow, endRow) {
+    const displayLayer = this.getTextEditor().displayLayer
+    const invisibleRegExp = this.getInvisibleRegExp()
+    const screenLines = displayLayer.getScreenLines(startRow, endRow)
+    let tokenLines = []
+    for (let {lineText, tagCodes} of screenLines) {
+      let tokens = []
+      let scopes = []
+      let textIndex = 0
+      for (let tagCode of tagCodes) {
+        if (displayLayer.isOpenTagCode(tagCode)) {
+          scopes.push(displayLayer.tagForCode(tagCode))
+        } else if (displayLayer.isCloseTagCode(tagCode)) {
+          scopes.pop()
+        } else {
+          tokens.push({
+            text: lineText.substr(textIndex, tagCode).replace(invisibleRegExp, ' '),
+            scopes: scopes.slice()
+          })
+          textIndex += tagCode
+        }
+      }
+
+      tokenLines.push(tokens)
+    }
+
+    return tokenLines
+  }
+
   /**
    * Draws lines on the corresponding layer.
    *
@@ -417,7 +447,6 @@ export default class CanvasDrawer extends Mixin {
     if (firstRow > lastRow) { return }
 
     const devicePixelRatio = this.minimap.getDevicePixelRatio()
-    const lines = this.getTextEditor().tokenizedLinesForScreenRows(firstRow, lastRow)
     const lineHeight = this.minimap.getLineHeight() * devicePixelRatio
     const charHeight = this.minimap.getCharHeight() * devicePixelRatio
     const charWidth = this.minimap.getCharWidth() * devicePixelRatio
@@ -425,34 +454,16 @@ export default class CanvasDrawer extends Mixin {
     const context = this.tokensLayer.context
     const {width: canvasWidth} = this.tokensLayer.getSize()
 
-    let line = lines[0]
-    const invisibleRegExp = this.getInvisibleRegExp(line)
-
-    for (let i = 0, len = lines.length; i < len; i++) {
-      line = lines[i]
-      const yRow = (offsetRow + i) * lineHeight
+    let y = offsetRow * lineHeight
+    for (let tokens of this.tokenLinesForScreenRows(firstRow, lastRow)) {
       let x = 0
-
-      if ((line != null ? line.tokens : void 0) != null) {
-        const tokens = line.tokens
-        for (let j = 0, tokensCount = tokens.length; j < tokensCount; j++) {
-          const token = tokens[j]
-          const w = token.screenDelta
-          if (!token.isOnlyWhitespace()) {
-            const color = displayCodeHighlights ? this.getTokenColor(token) : this.getDefaultColor()
-
-            let value = token.value
-            if (invisibleRegExp != null) {
-              value = value.replace(invisibleRegExp, ' ')
-            }
-            x = this.drawToken(context, value, color, x, yRow, charWidth, charHeight)
-          } else {
-            x += w * charWidth
-          }
-
-          if (x > canvasWidth) { break }
-        }
+      for (let token of tokens) {
+        const color = displayCodeHighlights ? this.getTokenColor(token) : this.getDefaultColor()
+        x = this.drawToken(context, token.text, color, x, y, charWidth, charHeight)
+        if (x > canvasWidth) { break }
       }
+
+      y += lineHeight
     }
 
     context.fill()
@@ -462,23 +473,18 @@ export default class CanvasDrawer extends Mixin {
    * Returns the regexp to replace invisibles substitution characters
    * in editor lines.
    *
-   * @param  {TokenizedLine} line a tokenized lize to read the invisible
-   *                              characters
    * @return {RegExp} the regular expression to match invisible characters
    * @access private
    */
-  getInvisibleRegExp (line) {
-    if ((line != null) && (line.invisibles != null)) {
-      const invisibles = []
-      if (line.invisibles.cr != null) { invisibles.push(line.invisibles.cr) }
-      if (line.invisibles.eol != null) { invisibles.push(line.invisibles.eol) }
-      if (line.invisibles.space != null) { invisibles.push(line.invisibles.space) }
-      if (line.invisibles.tab != null) { invisibles.push(line.invisibles.tab) }
+  getInvisibleRegExp () {
+    let invisibles = this.getTextEditor().getInvisibles()
+    let regexp = ''
+    if (invisibles.cr != null) { regexp += invisibles.cr + '|' }
+    if (invisibles.eol != null) { regexp += invisibles.eol + '|' }
+    if (invisibles.space != null) { regexp += invisibles.space + '|' }
+    if (invisibles.tab != null) { regexp += invisibles.tab + '|' }
 
-      return RegExp(invisibles.filter((s) => {
-        return typeof s === 'string'
-      }).map(_.escapeRegExp).join('|'), 'g')
-    }
+    return new RegExp(_.escapeRegExp(regexp.slice(0, -1)), 'g')
   }
 
   /**

--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -403,31 +403,37 @@ export default class CanvasDrawer extends Mixin {
   }
 
   tokenLinesForScreenRows (startRow, endRow) {
-    const displayLayer = this.getTextEditor().displayLayer
-    const invisibleRegExp = this.getInvisibleRegExp()
-    const screenLines = displayLayer.getScreenLines(startRow, endRow)
+    const editor = this.getTextEditor()
     let tokenLines = []
-    for (let {lineText, tagCodes} of screenLines) {
-      let tokens = []
-      let scopes = []
-      let textIndex = 0
-      for (let tagCode of tagCodes) {
-        if (displayLayer.isOpenTagCode(tagCode)) {
-          scopes.push(displayLayer.tagForCode(tagCode))
-        } else if (displayLayer.isCloseTagCode(tagCode)) {
-          scopes.pop()
-        } else {
-          tokens.push({
-            text: lineText.substr(textIndex, tagCode).replace(invisibleRegExp, ' '),
-            scopes: scopes.slice()
-          })
-          textIndex += tagCode
-        }
+    if (typeof editor.tokenizedLinesForScreenRows === "function") {
+      for (let tokenizedLine of editor.tokenizedLinesForScreenRows(startRow, endRow)) {
+        tokenLines.push(tokenizedLine.tokens)
       }
+    } else {
+      const displayLayer = editor.displayLayer
+      const invisibleRegExp = this.getInvisibleRegExp()
+      const screenLines = displayLayer.getScreenLines(startRow, endRow)
+      for (let {lineText, tagCodes} of screenLines) {
+        let tokens = []
+        let scopes = []
+        let textIndex = 0
+        for (let tagCode of tagCodes) {
+          if (displayLayer.isOpenTagCode(tagCode)) {
+            scopes.push(displayLayer.tagForCode(tagCode))
+          } else if (displayLayer.isCloseTagCode(tagCode)) {
+            scopes.pop()
+          } else {
+            tokens.push({
+              value: lineText.substr(textIndex, tagCode).replace(invisibleRegExp, ' '),
+              scopes: scopes.slice()
+            })
+            textIndex += tagCode
+          }
+        }
 
-      tokenLines.push(tokens)
+        tokenLines.push(tokens)
+      }
     }
-
     return tokenLines
   }
 
@@ -459,7 +465,7 @@ export default class CanvasDrawer extends Mixin {
       let x = 0
       for (let token of tokens) {
         const color = displayCodeHighlights ? this.getTokenColor(token) : this.getDefaultColor()
-        x = this.drawToken(context, token.text, color, x, y, charWidth, charHeight)
+        x = this.drawToken(context, token.value, color, x, y, charWidth, charHeight)
         if (x > canvasWidth) { break }
       }
 

--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -407,7 +407,13 @@ export default class CanvasDrawer extends Mixin {
     let tokenLines = []
     if (typeof editor.tokenizedLinesForScreenRows === 'function') {
       for (let tokenizedLine of editor.tokenizedLinesForScreenRows(startRow, endRow)) {
-        tokenLines.push(tokenizedLine.tokens)
+        const invisibleRegExp = this.getInvisibleRegExpForLine(tokenizedLine)
+        tokenLines.push(tokenizedLine.tokens.map((token) => {
+          return {
+            value: token.value.replace(invisibleRegExp, ' '),
+            scopes: token.scopes.slice()
+          }
+        }))
       }
     } else {
       const displayLayer = editor.displayLayer
@@ -491,6 +497,20 @@ export default class CanvasDrawer extends Mixin {
     if (invisibles.tab != null) { regexp += invisibles.tab + '|' }
 
     return new RegExp(_.escapeRegExp(regexp.slice(0, -1)), 'g')
+  }
+
+  getInvisibleRegExpForLine (line) {
+    if ((line != null) && (line.invisibles != null)) {
+      const invisibles = []
+      if (line.invisibles.cr != null) { invisibles.push(line.invisibles.cr) }
+      if (line.invisibles.eol != null) { invisibles.push(line.invisibles.eol) }
+      if (line.invisibles.space != null) { invisibles.push(line.invisibles.space) }
+      if (line.invisibles.tab != null) { invisibles.push(line.invisibles.tab) }
+
+      return RegExp(invisibles.filter((s) => {
+        return typeof s === 'string'
+      }).map(_.escapeRegExp).join('|'), 'g')
+    }
   }
 
   /**

--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -470,8 +470,12 @@ export default class CanvasDrawer extends Mixin {
     for (let tokens of this.tokenLinesForScreenRows(firstRow, lastRow)) {
       let x = 0
       for (let token of tokens) {
-        const color = displayCodeHighlights ? this.getTokenColor(token) : this.getDefaultColor()
-        x = this.drawToken(context, token.value, color, x, y, charWidth, charHeight)
+        if (/^\s+$/.test(token.value)) {
+          x += token.value.length * charWidth
+        } else {
+          const color = displayCodeHighlights ? this.getTokenColor(token) : this.getDefaultColor()
+          x = this.drawToken(context, token.value, color, x, y, charWidth, charHeight)
+        }
         if (x > canvasWidth) { break }
       }
 

--- a/lib/mixins/decoration-management.js
+++ b/lib/mixins/decoration-management.js
@@ -472,8 +472,6 @@ export default class DecorationManagement extends Mixin {
    * @access private
    */
   emitDecorationChanges (type, decoration) {
-    if (decoration.marker.isDestroyed()) { return }
-
     this.invalidateDecorationForScreenRowsCache()
 
     let range = decoration.marker.getScreenRange()

--- a/lib/mixins/decoration-management.js
+++ b/lib/mixins/decoration-management.js
@@ -472,7 +472,7 @@ export default class DecorationManagement extends Mixin {
    * @access private
    */
   emitDecorationChanges (type, decoration) {
-    if (decoration.marker.displayBuffer.isDestroyed()) { return }
+    if (decoration.marker.isDestroyed()) { return }
 
     this.invalidateDecorationForScreenRowsCache()
 

--- a/spec/minimap-element-spec.js
+++ b/spec/minimap-element-spec.js
@@ -518,7 +518,7 @@ describe('MinimapElement', () => {
 
             expect(minimapElement.drawLines).toHaveBeenCalled()
             expect(minimapElement.drawLines.argsForCall[0][0]).toEqual(100)
-            expect(minimapElement.drawLines.argsForCall[0][1]).toEqual(101)
+            expect(minimapElement.drawLines.argsForCall[0][1]).toEqual(102)
           })
         })
       })

--- a/spec/minimap-spec.js
+++ b/spec/minimap-spec.js
@@ -120,7 +120,7 @@ describe('Minimap', () => {
     it('adjust the scrolling ratio', () => {
       editorElement.setScrollTop(editorElement.getScrollHeight())
 
-      let maxScrollTop = editorElement.getScrollHeight() - editorElement.getHeight() - (editorElement.getHeight() - 3 * editor.displayBuffer.getLineHeightInPixels())
+      let maxScrollTop = editorElement.getScrollHeight() - editorElement.getHeight() - (editorElement.getHeight() - 3 * editor.getLineHeightInPixels())
 
       expect(minimap.getTextEditorScrollRatio()).toEqual(editorElement.getScrollTop() / maxScrollTop)
     })


### PR DESCRIPTION
These changes are an attempt at switching to the new `DisplayLayer` text decoration facilities (in a backward compatible manner), which have superseded some deprecated APIs, such as `tokenizedLineForScreenRow`. More informations in the [related PR](https://github.com/atom/atom/pull/11414).

@abe33: what do you think? I haven't tested this extensively, but definitely feel free to make any change you think would be needed to this branch (it's a fork, so I have given you collaborator access on my version of the repository).

Thanks! 🙇 