### PR TITLE
Fix closing bracets

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,8 +333,6 @@ html {
                     cursor: default;
                 } // Change cursor when dragging.
             }
-            
-            }
         }
         &:hover::shadow {
             .minimap-visible-area {


### PR DESCRIPTION
Caused by #498 

When copy+pasting it in my stylesheet there was an error.
````
Line number: 50
missing opening `{`
````