### PR TITLE
:memo: Add link to the quick-highlight integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Package|Description
 [Highlight Selected](https://atom.io/packages/minimap-highlight-selected)|A Minimap binding for the [highlight-selected](http://atom.io/packages/highlight-selected) package.
 [Linter](https://atom.io/packages/minimap-linter)|Displays [linter](https://atom.io/packages/linter) markers.
 [Pigments](https://atom.io/packages/minimap-pigments)|Displays the [Pigments](https://atom.io/packages/pigments) colors.
+[Quick-Highlight](https://atom.io/packages/minimap-quick-highlight)|Shows multiple selections done with the [quick-highlight](https://atom.io/packages/quick-highlight) package.
 [Selection](https://atom.io/packages/minimap-selection)|Display the buffer's selections.
 [Split-Diff](https://atom.io/packages/minimap-split-diff)|A Minimap binding for the [split-diff](https://atom.io/packages/split-diff) package.
 


### PR DESCRIPTION
[ci skip]
Just an extra line on the README