### PR TITLE
:ambulance: Fix #489

### DIFF
--- a/lib/adapters/stable-adapter.js
+++ b/lib/adapters/stable-adapter.js
@@ -123,6 +123,7 @@ module.exports = class StableAdapter {
   editorDestroyed () {
     return !this.textEditor ||
            this.textEditor.isDestroyed() ||
+           !this.textEditorElement.component ||
            !this.textEditorElement.getModel() ||
            !this.textEditorElement.parentNode
   }


### PR DESCRIPTION
If component is not defined, then the error found in https://github.com/atom-minimap/minimap/issues/489#issuecomment-273715210 will happen. This way we prevent that.

Fix #489 