### PR TITLE
Implement minimap redraw delay

### DIFF
--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -163,7 +163,6 @@ class Minimap {
      */
     this.configDevicePixelRatioRounding = null
     /**
-    /**
      * A boolean value to store whether this Minimap have been destroyed or not.
      *
      * @type {boolean}
@@ -178,6 +177,23 @@ class Minimap {
      * @access private
      */
     this.scrollPastEnd = false
+
+    /**
+     * An array of changes registered with textEditor.onDidChange() which have not yet been handled
+     *
+     * @type {Array}
+     * @access private
+     */
+    this.pendingChangeEvents = []
+
+    /**
+     * Timer reference which, once fired, will flush all the pending changes stored in
+     * this.pendingChangeEvents array.
+     *
+     * @type {Timer?}
+     * @access private
+     */
+    this.flushChangesTimer = null
 
     this.initializeDecorations()
 
@@ -234,7 +250,7 @@ class Minimap {
     }))
 
     subs.add(this.textEditor.onDidChange((changes) => {
-      this.emitChanges(changes)
+      this.scheduleChanges(changes)
     }))
     subs.add(this.textEditor.onDidDestroy(() => { this.destroy() }))
 
@@ -260,6 +276,9 @@ class Minimap {
   destroy () {
     if (this.destroyed) { return }
 
+    clearTimeout(this.flushChangesTimer)
+    this.flushChangesTimer = null
+    this.pendingChangeEvents = []
     this.removeAllDecorations()
     this.subscriptions.dispose()
     this.subscriptions = null
@@ -275,6 +294,36 @@ class Minimap {
    * @return {boolean} whether this Minimap has been destroyed or not
    */
   isDestroyed () { return this.destroyed }
+
+  /**
+   * Schedule changes from textEditor.onDidChange() to be handled at a later time
+   *
+   * @param  {Array} changes The changes to be scheduled
+   * @return void
+   * @access private
+   */
+  scheduleChanges (changes) {
+    this.pendingChangeEvents.push(...changes)
+
+    // If any changes happened within the timeout's delay, a timeout will already have been
+    // scheduled -> no need to schedule again
+    if (!this.flushChangesTimer) {
+      this.flushChangesTimer = setTimeout(() => { this.flushChanges() }, 1000)
+    }
+  }
+
+  /**
+   * Flush all changes which have been scheduled for later processing by this.scheduleChanges()
+   *
+   * @return void
+   * @access private
+   */
+  flushChanges () {
+    clearTimeout(this.flushChangesTimer)
+    this.flushChangesTimer = null
+    this.emitChanges(this.pendingChangeEvents)
+    this.pendingChangeEvents = []
+  }
 
   /**
    * Registers an event listener to the `did-change` event.

--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -163,6 +163,15 @@ class Minimap {
      */
     this.configDevicePixelRatioRounding = null
     /**
+     * A number of milliseconds which determines how often the minimap should redraw itself after
+     * detecting changes in the text editor. A value of 0 will cause the minimap to redraw
+     * immediately.
+     *
+     * @type {number}
+     * @access private
+     */
+    this.redrawDelay = 0
+    /**
      * A boolean value to store whether this Minimap have been destroyed or not.
      *
      * @type {boolean}
@@ -305,10 +314,15 @@ class Minimap {
   scheduleChanges (changes) {
     this.pendingChangeEvents.push(...changes)
 
-    // If any changes happened within the timeout's delay, a timeout will already have been
-    // scheduled -> no need to schedule again
+    // Optimisation: If the redraw delay is set to 0, do not even schedule a timer
+    if (!this.redrawDelay) {
+      return this.flushChanges()
+    }
+
     if (!this.flushChangesTimer) {
-      this.flushChangesTimer = setTimeout(() => { this.flushChanges() }, 1000)
+      // If any changes happened within the timeout's delay, a timeout will already have been
+      // scheduled -> no need to schedule again
+      this.flushChangesTimer = setTimeout(() => { this.flushChanges() }, this.redrawDelay)
     }
   }
 
@@ -454,6 +468,9 @@ class Minimap {
     }))
     subs.add(atom.config.observe('minimap.scrollSensitivity', opts, (scrollSensitivity) => {
       this.scrollSensitivity = scrollSensitivity
+    }))
+    subs.add(atom.config.observe('minimap.redrawDelay', opts, (redrawDelay) => {
+      this.redrawDelay = redrawDelay
     }))
     // cdprr is shorthand for configDevicePixelRatioRounding
     subs.add(atom.config.observe(

--- a/package.json
+++ b/package.json
@@ -71,6 +71,13 @@
       "type": "boolean",
       "default": true
     },
+    "redrawDelay": {
+      "type": "number",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 1000,
+      "description": "Controls how often (in ms) the minimap should redraw itself after changing the text editor's contents. Setting this to 100ms or higher could dramatically improve editor responsiveness when working with large files. A value of 0 will cause the minimap to redraw itself immediately on each change."
+    },
     "adjustMinimapWidthToSoftWrap": {
       "type": "boolean",
       "default": true,


### PR DESCRIPTION
# What is this

This PR introduces a change which causes `textEditor.onDidChange()` events to be dispatched at certain intervals instead of immediately. The delay is controlled by a new configuration option, `Redraw delay`.

# Why?

When working with large files, causing the minimap to redraw itself after each keystroke brings Atom down to its kneels and drops the viewport's refresh rate to about 10fps. By grouping the change events and firing them only after certain interval, we can significantly increase performance and the editor's responsiveness back to normal.

Below you may find a performance timeline which compares Atom's performance before and after this change.

### Before

> Redraw minimap on each keystroke

![minimap - performance - before](https://cloud.githubusercontent.com/assets/3058150/24250093/f8c3889c-0fd5-11e7-886b-823f0757707a.png)

### After

> Redraw minimap only once per second

The framerate is **way** higher and the execution stacks after each keystroke are much shorter -> 🐎 ❤️

![minimap - performance - after](https://cloud.githubusercontent.com/assets/3058150/24250306/acd35e8e-0fd6-11e7-9918-c0e7eb3828de.png)

# New config option

![Redraw delay - config option](https://cloud.githubusercontent.com/assets/3058150/24250509/693d02dc-0fd7-11e7-84d3-6c6a9358c2a4.png)

# Implementation details

The changes minimap receives from `textEditor.onDidChange()` are stored in an internal buffer, `minimap.pendingChangeEvents` array. When a change event is received, a timer is set up which, once fired, will flush all the change events received so far to the emitter object, thus causing the minimap to redraw its contents.

## TODOs

I could really use help writing spec for this change.

Fixes #580, #578 