### PR TITLE
Use IntersectionObserver and resize-detector when possible

### DIFF
--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -5,6 +5,7 @@ const DOMStylesReader = require('./mixins/dom-styles-reader')
 const CanvasDrawer = require('./mixins/canvas-drawer')
 const include = require('./decorators/include')
 const element = require('./decorators/element')
+const elementResizeDetector = require('element-resize-detector')({strategy: 'scroll'})
 
 let Main, MinimapQuickSettingsElement, CompositeDisposable, Disposable, overlayStyle
 
@@ -342,7 +343,29 @@ class MinimapElement {
    * @access private
    */
   attachedCallback () {
-    this.subscriptions.add(atom.views.pollDocument(() => { this.pollDOM() }))
+    if (atom.views.pollDocument) {
+      this.subscriptions.add(atom.views.pollDocument(() => { this.pollDOM() }))
+    } else {
+      this.intersectionObserver = new IntersectionObserver((entries) => {
+        const {intersectionRect} = entries[entries.length - 1]
+        if (intersectionRect.width > 0 || intersectionRect.height > 0) {
+          this.measureHeightAndWidth(true, true)
+        }
+      })
+
+      this.intersectionObserver.observe(this)
+      if (this.isVisible()) {
+        this.measureHeightAndWidth(true, true)
+      }
+
+      const measureDimensions = () => { this.measureHeightAndWidth(false, false) }
+      elementResizeDetector.listenTo(this, measureDimensions)
+      this.subscriptions.add(new Disposable(() => { elementResizeDetector.removeListener(this, measureDimensions) }))
+
+      window.addEventListener('resize', measureDimensions)
+      this.subscriptions.add(new Disposable(() => { window.removeEventListener('resize', measureDimensions) }))
+    }
+
     this.measureHeightAndWidth()
     this.updateMinimapFlexPosition()
     this.attached = true

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
   "dependencies": {
     "atom-utils": ">=0.9.2",
     "delegato": "1.x",
+    "element-resize-detector": "^1.1.11",
     "fs-plus": "2.x",
     "mixto": "1.x",
     "underscore-plus": "1.x"

--- a/package.json
+++ b/package.json
@@ -199,7 +199,8 @@
       "devicePixelRatio",
       "requestAnimationFrame",
       "Event",
-      "MouseEvent"
+      "MouseEvent",
+      "IntersectionObserver"
     ]
   }
 }

--- a/spec/minimap-element-spec.js
+++ b/spec/minimap-element-spec.js
@@ -1377,7 +1377,9 @@ describe('MinimapElement', () => {
 
       describe('the dom polling routine', () => {
         it('does not change the value', () => {
-          atom.views.performDocumentPoll?()
+          if (atom.views.performDocumentPoll) {
+            atom.views.performDocumentPoll()
+          }
 
           waitsFor('a new animation frame request', () => {
             return nextAnimationFrame !== noAnimationFrame
@@ -1395,7 +1397,9 @@ describe('MinimapElement', () => {
           editorElement.style.width = '100px'
           editorElement.style.height = '100px'
 
-          atom.views.performDocumentPoll?()
+          if (atom.views.performDocumentPoll) {
+            atom.views.performDocumentPoll()
+          }
 
           waitsFor('a new animation frame request', () => {
             return nextAnimationFrame !== noAnimationFrame
@@ -1525,7 +1529,9 @@ describe('MinimapElement', () => {
         beforeEach(() => {
           editorElement.style.height = '500px'
 
-          atom.views.performDocumentPoll?()
+          if (atom.views.performDocumentPoll) {
+            atom.views.performDocumentPoll()
+          }
 
           waitsFor('a new animation frame request', () => {
             return nextAnimationFrame !== noAnimationFrame
@@ -1747,7 +1753,10 @@ describe('MinimapElement', () => {
 
           editorElement.style.width = '1024px'
 
-          atom.views.performDocumentPoll?()
+          if (atom.views.performDocumentPoll) {
+            atom.views.performDocumentPoll()
+          }
+
           waitsFor('minimap frame requested', () => {
             return minimapElement.frameRequested
           })

--- a/spec/minimap-element-spec.js
+++ b/spec/minimap-element-spec.js
@@ -1377,7 +1377,7 @@ describe('MinimapElement', () => {
 
       describe('the dom polling routine', () => {
         it('does not change the value', () => {
-          atom.views.performDocumentPoll()
+          atom.views.performDocumentPoll?()
 
           waitsFor('a new animation frame request', () => {
             return nextAnimationFrame !== noAnimationFrame
@@ -1395,7 +1395,7 @@ describe('MinimapElement', () => {
           editorElement.style.width = '100px'
           editorElement.style.height = '100px'
 
-          atom.views.performDocumentPoll()
+          atom.views.performDocumentPoll?()
 
           waitsFor('a new animation frame request', () => {
             return nextAnimationFrame !== noAnimationFrame
@@ -1525,7 +1525,7 @@ describe('MinimapElement', () => {
         beforeEach(() => {
           editorElement.style.height = '500px'
 
-          atom.views.performDocumentPoll()
+          atom.views.performDocumentPoll?()
 
           waitsFor('a new animation frame request', () => {
             return nextAnimationFrame !== noAnimationFrame
@@ -1747,7 +1747,7 @@ describe('MinimapElement', () => {
 
           editorElement.style.width = '1024px'
 
-          atom.views.performDocumentPoll()
+          atom.views.performDocumentPoll?()
           waitsFor('minimap frame requested', () => {
             return minimapElement.frameRequested
           })


### PR DESCRIPTION
As discussed on Slack, `atom.views.pollDocument` is going to be removed from `ViewRegistry` soon because of its inefficiency. This pull request takes advantage of `resize-detector` and the new `IntersectionObserver` API to detect changes in the minimap element when `atom.views.pollDocument` can't be found.

/cc: @abe33 