### PR TITLE
Guard against service usage after package is disabled in the same Atom session

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -317,6 +317,7 @@ class Main {
    */
   minimapForEditor (textEditor) {
     if (!textEditor) { return }
+    if (!this.editorsMinimaps) { return }
 
     let minimap = this.editorsMinimaps.get(textEditor)
 


### PR DESCRIPTION
Fixes #605

---

This is because a deactivate sets `this.editorsMinimaps` to `undefined` but plugins still have a reference to this package instance.