### PR TITLE
Fix left side minimap depreciation

### DIFF
--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -227,6 +227,7 @@ class MinimapElement {
           ? ensureOverlayStyle()
           : removeOverlayStyle()
         this.updateMinimapFlexPosition()
+        this.measureHeightAndWidth(true, true)
       },
 
       'minimap.minimapScrollIndicator': (minimapScrollIndicator) => {

--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -27,8 +27,8 @@ const removeOverlayStyle = () => {
 const updateOverlayStyle = (basis) => {
   if (overlayStyle) {
     overlayStyle.textContent = `
-    atom-text-editor[with-minimap]::shadow atom-overlay,
-    atom-text-editor[with-minimap] atom-overlay {
+    atom-text-editor[with-minimap].editor > div,
+    atom-text-editor[with-minimap] > div {
       margin-left: ${basis}px;
     }
     `

--- a/styles/minimap.less
+++ b/styles/minimap.less
@@ -29,6 +29,7 @@ atom-text-editor, html {
 
       &.left {
         order: 1;
+        position: absolute;
       }
     }
 
@@ -47,7 +48,6 @@ atom-text-editor, html {
       // absolute mode do nothing when the minimap is on the left, because
       // it would conflict with the editor's gutter
       &.left {
-        position: relative;
         right: initial;
       }
 


### PR DESCRIPTION
Atom 1.19.0 broke the minimap on the left side #623. Furthermore there was an issue about depreciated selectors #613. This is a quick fix which I think solves both of those issue. 

I'm quite new to JS, so please let me know if there are any improvements I can make. Feel free also to simply use my PR as inspiration for a better fix.

Best.