### PR TITLE
fix(README): broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ To generate these comments you can use on these useful Atom packages:
 
 ### Developers Documentation
 
-- [Developers Documentation](http://github.com/atom-minimap/minimap/docs/Developers Documentation.md)
+- [Developers Documentation](https://github.com/atom-minimap/minimap/blob/master/docs/Developers%20Documentation.md)
 - [Minimap API Documentation](http://atom-minimap.github.io/minimap/)
 
 ### License


### PR DESCRIPTION
urls cannot contain unencoded spaces