### PR TITLE
Use proper method to subscribe to onDidTokenize

### DIFF
--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -270,11 +270,7 @@ class Minimap {
     resulting in extra lines appearing at the end of the minimap.
     Forcing a whole repaint to fix that bug is suboptimal but works.
     */
-    const tokenizedBuffer = this.textEditor.tokenizedBuffer
-      ? this.textEditor.tokenizedBuffer
-      : this.textEditor.displayBuffer.tokenizedBuffer
-
-    subs.add(tokenizedBuffer.onDidTokenize(() => {
+    subs.add(this.textEditor.onDidTokenize(() => {
       this.emitter.emit('did-change-config')
     }))
   }


### PR DESCRIPTION
Way back in https://github.com/atom/atom/commit/117a3fb1b57465e3164c378219eefcca4b5c22a5 (released in Atom v1.9.0-beta0) Atom introduced an experimental TextEditor::onDidTokenize method in order to subscribe to that event. Switch to using this instead of grabbing it through the private properties which no longer work as of [Atom v1.25.0-beta0](https://github.com/atom/atom/releases/tag/v1.25.0-beta0).

Note that this is still present in the [current codebase](https://github.com/atom/atom/blob/b9e4febf03f29ab4327b3b64d528cfbcbd6fb9b5/src/text-editor.js#L3631).

Fixes #649.