### PR TITLE
caught requestAnimationFrame error

### DIFF
--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -774,12 +774,14 @@ class MinimapElement {
    */
   requestUpdate () {
     if (this.frameRequested) { return }
-
     this.frameRequested = true
-    requestAnimationFrame(() => {
-      this.update()
-      this.frameRequested = false
-    })
+    try{
+      requestAnimationFrame(() => {
+        this.update()
+        this.frameRequested = false
+      })
+    } catch(e if e instanceof TypeError) {
+    }
   }
 
   /**
@@ -1381,7 +1383,11 @@ class MinimapElement {
       const value = from + (to - from) * delta
       step(value, delta)
 
-      if (progress < 1) { requestAnimationFrame(update) }
+      if (progress < 1) {
+        try{
+          requestAnimationFrame(update)
+        } catch(e if e instanceof TypeError)
+      }
     }
 
     update()


### PR DESCRIPTION
Resolves issue #648 , where an uncaught TypeError was thrown in the minimap/lib/minimap-elements.js file when calling requestAnimationFrame. 