### PR TITLE
default-cursor: Use default cursor for atom-text-editr-minimap

### DIFF
--- a/lib/adapters/stable-adapter.js
+++ b/lib/adapters/stable-adapter.js
@@ -57,12 +57,12 @@ module.exports = class StableAdapter {
     const scrollTop = this.textEditorElement.getScrollTop()
     const lineHeight = this.textEditor.getLineHeightInPixels()
     let firstRow = this.textEditorElement.getFirstVisibleScreenRow()
-    
+
     if (Number.isNaN(firstRow)) {
       // Guard against their being no visible screen row
       return 0
     }
-    
+
     let lineTop = this.textEditorElement.pixelPositionForScreenPosition([firstRow, 0]).top
 
     if (lineTop > scrollTop) {

--- a/styles/minimap.less
+++ b/styles/minimap.less
@@ -20,6 +20,7 @@ atom-text-editor, html {
     overflow: hidden;
     position: relative;
     -webkit-user-select: none;
+    cursor: default;
 
     &:not([stand-alone]) {
       height: 100%;


### PR DESCRIPTION
This is a UX improvement to show the `default` cursor instead of the `text` one.

With the `text` cursor looked like it was possible to select text on the minimap or the text back it if using the absolute mode.

Edit: I added a commit to be able to pass the builds.