### PR TITLE
Improve 'hiding scrollbars' tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,7 @@ If you want to hide the default editor scrollbar, edit your `style.less` (Open Y
 
 ```css
 atom-text-editor[with-minimap] .vertical-scrollbar {
-  opacity: 0;
-  width: 0;
+  display: none;
 }
 ```
 


### PR DESCRIPTION
Rather than merely visually hiding the scrollbar (you are still able to still click on it even if it is invisible), this change means that the scrollbar is actually not there.