### PR TITLE
Make event listeners passive

### DIFF
--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -363,7 +363,7 @@ class MinimapElement {
       elementResizeDetector.listenTo(this, measureDimensions)
       this.subscriptions.add(new Disposable(() => { elementResizeDetector.removeListener(this, measureDimensions) }))
 
-      window.addEventListener('resize', measureDimensions)
+      window.addEventListener('resize', measureDimensions, { passive: true })
       this.subscriptions.add(new Disposable(() => { window.removeEventListener('resize', measureDimensions) }))
     }
 
@@ -1229,13 +1229,13 @@ class MinimapElement {
     let touchmoveHandler = (e) => this.drag(this.extractTouchEventData(e), initial)
     let touchendHandler = (e) => this.endDrag()
 
-    document.body.addEventListener('mousemove', mousemoveHandler)
-    document.body.addEventListener('mouseup', mouseupHandler)
-    document.body.addEventListener('mouseleave', mouseupHandler)
+    document.body.addEventListener('mousemove', mousemoveHandler, { passive: true })
+    document.body.addEventListener('mouseup', mouseupHandler, { passive: true })
+    document.body.addEventListener('mouseleave', mouseupHandler, { passive: true })
 
-    document.body.addEventListener('touchmove', touchmoveHandler)
-    document.body.addEventListener('touchend', touchendHandler)
-    document.body.addEventListener('touchcancel', touchendHandler)
+    document.body.addEventListener('touchmove', touchmoveHandler, { passive: true })
+    document.body.addEventListener('touchend', touchendHandler, { passive: true })
+    document.body.addEventListener('touchcancel', touchendHandler, { passive: true })
 
     this.dragSubscription = new Disposable(function () {
       document.body.removeEventListener('mousemove', mousemoveHandler)


### PR DESCRIPTION
Marking event listeners as passive, indicates that the callback will never call `event.preventDefault()`. This can improve scolling performance in many cases.

For more information on passive event listeners see: https://developers.google.com/web/updates/2016/06/passive-event-listeners