### PR TITLE
Mark atom-utils event listeners as passive

### DIFF
--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -493,7 +493,7 @@ class MinimapElement {
           this.minimap.onMouseWheel(e)
         }
       }
-    }))
+    }, { passive: true }))
 
     this.subscriptions.add(this.subscribeTo(this.getFrontCanvas(), {
       mousedown: (e) => { this.canvasPressed(this.extractMouseEventData(e)) },

--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -498,7 +498,7 @@ class MinimapElement {
     this.subscriptions.add(this.subscribeTo(this.getFrontCanvas(), {
       mousedown: (e) => { this.canvasPressed(this.extractMouseEventData(e)) },
       touchstart: (e) => { this.canvasPressed(this.extractTouchEventData(e)) }
-    }))
+    }, { passive: true }))
   }
 
   /**
@@ -515,7 +515,7 @@ class MinimapElement {
     this.visibleAreaSubscription = this.subscribeTo(this.visibleArea, {
       mousedown: (e) => { this.startDrag(this.extractMouseEventData(e)) },
       touchstart: (e) => { this.startDrag(this.extractTouchEventData(e)) }
-    })
+    }, { passive: true })
 
     this.subscriptions.add(this.visibleAreaSubscription)
   }

--- a/lib/minimap-quick-settings-element.js
+++ b/lib/minimap-quick-settings-element.js
@@ -117,7 +117,7 @@ class MinimapQuickSettingsElement {
 
     subs.add(this.subscribeTo(this.hiddenInput, {
       focusout: (e) => { this.destroy() }
-    }))
+    }, { passive: true }))
 
     subs.add(this.subscribeTo(this.onLeftButton, {
       mousedown: (e) => {


### PR DESCRIPTION
Marking event listeners as passive, indicates that the callback will never call `event.preventDefault()`. This can greatly improve scrolling performance. 

This removes multiple warning in the dev console:
```
[Violation] Added non-passive event listener to a scroll-blocking 'touchstart' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952
```

For more information on passive event listeners see: https://developers.google.com/web/updates/2016/06/passive-event-listeners

:warning: This PR requires https://github.com/abe33/atom-utils/pull/3 to work correctly.