### PR TITLE
fix: prevent error when minimap squashed

### DIFF
--- a/lib/canvas-layer.js
+++ b/lib/canvas-layer.js
@@ -73,11 +73,13 @@ module.exports = class CanvasLayer {
   }
 
   copyPartFromOffscreen (srcY, destY, height) {
-    this.context.drawImage(
-      this.offscreenCanvas,
-      0, srcY, this.offscreenCanvas.width, height,
-      0, destY, this.offscreenCanvas.width, height
-    )
+    if (this.offscreenCanvas.width > 0 && this.offscreenCanvas.height > 0) {
+      this.context.drawImage(
+        this.offscreenCanvas,
+        0, srcY, this.offscreenCanvas.width, height,
+        0, destY, this.offscreenCanvas.width, height
+      )
+    }
   }
 
   clearCanvas () {

--- a/lib/canvas-layer.js
+++ b/lib/canvas-layer.js
@@ -61,11 +61,15 @@ module.exports = class CanvasLayer {
   }
 
   copyToOffscreen () {
-    this.offscreenContext.drawImage(this.canvas, 0, 0)
+    if (this.canvas.width > 0 && this.canvas.height > 0) {
+      this.offscreenContext.drawImage(this.canvas, 0, 0)
+    }
   }
 
   copyFromOffscreen () {
-    this.context.drawImage(this.offscreenCanvas, 0, 0)
+    if (this.offscreenCanvas.width > 0 && this.offscreenCanvas.height > 0) {
+      this.context.drawImage(this.offscreenCanvas, 0, 0)
+    }
   }
 
   copyPartFromOffscreen (srcY, destY, height) {


### PR DESCRIPTION
Fix error when the middle pane is 0 width

![minimap-width](https://user-images.githubusercontent.com/97994/89725541-2a0dd600-d9d6-11ea-88ca-e5508cf4a2fb.gif)

Fixes https://github.com/atom-ide-community/minimap-plus/issues/15
Fixes https://github.com/atom-minimap/minimap/issues/702

Originally posted at https://github.com/atom-ide-community/minimap-plus/pull/13#issue-465109156 by @UziTech 