### PR TITLE
feat: limit the number of tokens that are rendered for one line

### DIFF
--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -61,7 +61,7 @@ module.exports = class CanvasDrawer extends Mixin {
     }
 
     // the maximum number of tokens to render in one line
-    this.maxTokensInOneLine = atom.config.get("minimap.maxTokensInOneLine")
+    this.maxTokensInOneLine = atom.config.get('minimap.maxTokensInOneLine')
   }
 
   /**
@@ -421,7 +421,7 @@ module.exports = class CanvasDrawer extends Mixin {
     for (let row = startRow; row < endRow; row++) {
       const editorTokensForScreenRow = editor.tokensForScreenRow(row)
       const numToken = editorTokensForScreenRow.length
-      const numTokenToRender = Math.min(numToken, this.maxTokensInOneLine);
+      const numTokenToRender = Math.min(numToken, this.maxTokensInOneLine)
       for (let iToken = 0; iToken < numTokenToRender; iToken++) {
         const token = editorTokensForScreenRow[iToken]
         callback(row, {

--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -59,6 +59,9 @@ module.exports = class CanvasDrawer extends Mixin {
        */
       this.pendingFrontDecorationChanges = []
     }
+
+    // the maximum number of tokens to render in one line
+    this.maxTokensInOneLine = atom.config.get("minimap.maxTokensInOneLine")
   }
 
   /**
@@ -416,12 +419,16 @@ module.exports = class CanvasDrawer extends Mixin {
     endRow = Math.min(endRow, editor.getScreenLineCount())
 
     for (let row = startRow; row < endRow; row++) {
-      editor.tokensForScreenRow(row).forEach(token => {
+      const editorTokensForScreenRow = editor.tokensForScreenRow(row)
+      const numToken = editorTokensForScreenRow.length
+      const numTokenToRender = Math.min(numToken, this.maxTokensInOneLine);
+      for (let iToken = 0; iToken < numTokenToRender; iToken++) {
+        const token = editorTokensForScreenRow[iToken]
         callback(row, {
           text: token.text.replace(invisibleRegExp, ' '),
           scopes: token.scopes
         })
-      })
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -194,6 +194,12 @@
       "default": 300,
       "description": "The duration of scrolling animations when clicking on the minimap.",
       "order": 24
+    },
+    "maxTokensInOneLine": {
+      "type": "integer",
+      "default": 160,
+      "description": "The maximum number of tokens that are rendered for each line.",
+      "order": 25
     }
   },
   "dependencies": {


### PR DESCRIPTION
This will prevent the very long lines to break minimap when softwrap is not enabled.

Originally posted at https://github.com/atom-ide-community/minimap-plus/commit/4df465572cc7c58f5032d54bcd262119ae574898