### PR TITLE
fix: make scroll indicator more visible

### DIFF
--- a/styles/minimap.less
+++ b/styles/minimap.less
@@ -111,7 +111,7 @@ atom-text-editor, html {
       width: 2px;
       min-height: 2px;
       z-index: 10;
-      background: @background-color-selected;
+      background: #fff - @background-color-selected; // invert color
     }
 
     .open-minimap-quick-settings {

--- a/styles/minimap.less
+++ b/styles/minimap.less
@@ -108,7 +108,7 @@ atom-text-editor, html {
       position: absolute;
       display: block;
       right: 0;
-      width: 2px;
+      width: 1.5px;
       min-height: 2px;
       z-index: 10;
       background: #fff - @background-color-selected; // invert color


### PR DESCRIPTION
Fixes #723 

The color and width of the scroll indicator make it almost invisible (especially for people with low sight or color blindness). 

Before this PR, I could not see this scroll indicator until I hacked its color in the dev editor, and I finally noticed that this scroll indicator is actually a thing!

I think we can still improve the scroll indicator:
- Currently, it is only shown if the minimap is longer than the height of the editor.

Normal:
![image](https://user-images.githubusercontent.com/16418197/100288795-13679c80-2f3d-11eb-8a5c-2e8c97173689.png)

![image](https://user-images.githubusercontent.com/16418197/100288792-11054280-2f3d-11eb-9915-d7007b54a7e5.png)

Absolute mode:
![image](https://user-images.githubusercontent.com/16418197/100289056-abfe1c80-2f3d-11eb-8f63-7fdb3acff18f.png)
![image](https://user-images.githubusercontent.com/16418197/100289081-b5878480-2f3d-11eb-88f7-0df04743872d.png)
