### PR TITLE
fix: disable desynchronized canvas on Linux

### DIFF
--- a/lib/canvas-layer.js
+++ b/lib/canvas-layer.js
@@ -10,11 +10,15 @@ module.exports = class CanvasLayer {
      * @type {HTMLCanvasElement}
      */
     this.canvas = document.createElement('canvas')
+
+    const desynchronized = process.platform !== "linux"
+    const lowLatency = desynchronized
+
     /**
      * The onscreen canvas context.
      * @type {CanvasRenderingContext2D}
      */
-    this.context = this.canvas.getContext('2d', { desynchronized: true })
+    this.context = this.canvas.getContext('2d', { desynchronized: desynchronized, lowLatency: lowLatency })
     this.canvas.webkitImageSmoothingEnabled = false
     this.context.imageSmoothingEnabled = false
 
@@ -29,7 +33,7 @@ module.exports = class CanvasLayer {
      * @type {CanvasRenderingContext2D}
      * @access private
      */
-    this.offscreenContext = this.offscreenCanvas.getContext('2d', { desynchronized: true })
+    this.offscreenContext = this.offscreenCanvas.getContext('2d', { desynchronized: desynchronized, lowLatency: lowLatency })
     this.offscreenCanvas.webkitImageSmoothingEnabled = false
     this.offscreenContext.imageSmoothingEnabled = false
   }


### PR DESCRIPTION
we should fall back to the traditional canvas for the operating systems that do not support low-latency rendering.
https://developers.google.com/web/updates/2019/05/desynchronized#feature_detection
https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext


Fixes #724 