### PR TITLE
chore: remove kite sponsor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 A preview of the full source code.
 
-This package is sponsored and maintained by [Kite](https://kite.com/docs?source=minimap).
-
 ![Minimap Screenshot](https://github.com/atom-minimap/minimap/blob/master/resources/screenshot.png?raw=true)
 <small>In the screenshot above the minimap-git-diff and minimap-highlight-selected plugins are activated.</small>
 


### PR DESCRIPTION
I emailed an employee at kite and he said that he couldn't find anyone at the company who knew anything about minimap so I'm pretty sure we can remove the sponsorship statement. 