### PR TITLE
fix: use strings interpolation instead of + and shorter version of object props

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -312,7 +312,7 @@ export function standAloneMinimapForEditor (textEditor) {
   if (!textEditor) { return }
 
   return new Minimap({
-    textEditor: textEditor,
+    textEditor,
     standAlone: true
   })
 }

--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -1109,13 +1109,13 @@ class MinimapElement {
           this.minimap.setTextEditorScrollTop(now, true)
           this.minimap.setScrollTop(minimapFrom + (minimapTo - minimapFrom) * t)
         }
-        animate({ from: from, to: to, duration: duration, step: step })
+        animate({ from, to, duration, step })
       } else {
         step = (now) => {
           if (this.minimap === null) return // TODO why this happens in the tests?
           this.minimap.setTextEditorScrollTop(now)
         }
-        animate({ from: from, to: to, duration: duration, step: step })
+        animate({ from, to, duration, step })
       }
     } else {
       this.minimap.setTextEditorScrollTop(textEditorScrollTop)

--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -634,13 +634,13 @@ class MinimapElement {
           })
 
           const { top, left, right } = this.getFrontCanvas().getBoundingClientRect()
-          this.quickSettingsElement.style.top = top + 'px'
+          this.quickSettingsElement.style.top = `${top}px`
           this.quickSettingsElement.attach()
 
           if (this.displayMinimapOnLeft) {
-            this.quickSettingsElement.style.left = (right) + 'px'
+            this.quickSettingsElement.style.left = `${right}px`
           } else {
-            this.quickSettingsElement.style.left = (left - this.quickSettingsElement.clientWidth) + 'px'
+            this.quickSettingsElement.style.left = `${left - this.quickSettingsElement.clientWidth}px`
           }
         }
       }
@@ -830,8 +830,8 @@ class MinimapElement {
     const visibleWidth = width + visibleAreaLeft
 
     if (this.adjustToSoftWrap && this.flexBasis) {
-      this.style.flexBasis = this.flexBasis + 'px'
-      this.style.width = this.flexBasis + 'px'
+      this.style.flexBasis = `${this.flexBasis}px`
+      this.style.width = `${this.flexBasis}px`
     } else {
       this.style.flexBasis = null
       this.style.width = null
@@ -839,34 +839,34 @@ class MinimapElement {
 
     if (SPEC_MODE) {
       applyStyles(this.visibleArea, {
-        width: Math.round(visibleWidth) + 'px',
-        height: Math.round(minimap.getTextEditorScaledHeight()) + 'px',
-        top: Math.round(visibleAreaTop) + 'px',
-        'border-left-width': Math.round(visibleAreaLeft) + 'px'
+        width: `${Math.round(visibleWidth)}px`,
+        height: `${Math.round(minimap.getTextEditorScaledHeight())}px`,
+        top: `${Math.round(visibleAreaTop)}px`,
+        'border-left-width': `${Math.round(visibleAreaLeft)}px`
       })
     } else {
       applyStyles(this.visibleArea, {
-        width: Math.round(visibleWidth) + 'px',
-        height: Math.round(minimap.getTextEditorScaledHeight()) + 'px',
+        width: `${Math.round(visibleWidth)}px`,
+        height: `${Math.round(minimap.getTextEditorScaledHeight())}px`,
         transform: makeTranslate(0, visibleAreaTop, this.useHardwareAcceleration),
-        'border-left-width': Math.round(visibleAreaLeft) + 'px'
+        'border-left-width': `${Math.round(visibleAreaLeft)}px`
       })
     }
 
-    applyStyles(this.controls, { width: Math.round(width) + 'px' })
+    applyStyles(this.controls, { width: `${Math.round(width)}px` })
 
     const canvasTop = minimap.getFirstVisibleScreenRow() * minimap.getLineHeight() - minimap.getScrollTop()
 
     if (this.smoothScrolling) {
       if (SPEC_MODE) {
-        applyStyles(this.backLayer.canvas, { top: canvasTop + 'px' })
-        applyStyles(this.tokensLayer.canvas, { top: canvasTop + 'px' })
-        applyStyles(this.frontLayer.canvas, { top: canvasTop + 'px' })
+        applyStyles(this.backLayer.canvas, { top: `${canvasTop}px` })
+        applyStyles(this.tokensLayer.canvas, { top: `${canvasTop}px` })
+        applyStyles(this.frontLayer.canvas, { top: `${canvasTop}px` })
       } else {
         let canvasTransform = makeTranslate(0, canvasTop, this.useHardwareAcceleration)
         if (devicePixelRatio !== 1) {
           const scale = 1 / devicePixelRatio
-          canvasTransform += ' ' + makeScale(scale, scale, this.useHardwareAcceleration)
+          canvasTransform += ` ${makeScale(scale, scale, this.useHardwareAcceleration)}`
         }
         applyStyles(this.backLayer.canvas, { transform: canvasTransform })
         applyStyles(this.tokensLayer.canvas, { transform: canvasTransform })
@@ -891,12 +891,12 @@ class MinimapElement {
 
       if (SPEC_MODE) {
         applyStyles(this.scrollIndicator, {
-          height: indicatorHeight + 'px',
-          top: indicatorScroll + 'px'
+          height: `${indicatorHeight}px`,
+          top: `${indicatorScroll}px`
         })
       } else {
         applyStyles(this.scrollIndicator, {
-          height: indicatorHeight + 'px',
+          height: `${indicatorHeight}px`,
           transform: makeTranslate(0, indicatorScroll, this.useHardwareAcceleration)
         })
       }

--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -336,11 +336,11 @@ export default class CanvasDrawer extends Mixin {
     const { width: canvasWidth, height: canvasHeight } = this.tokensLayer.getSize()
     const renderData = {
       context: this.backLayer.context,
-      canvasWidth: canvasWidth,
-      canvasHeight: canvasHeight,
-      lineHeight: lineHeight,
-      charWidth: charWidth,
-      charHeight: charHeight,
+      canvasWidth,
+      canvasHeight,
+      lineHeight,
+      charWidth,
+      charHeight,
       orders: Main.getPluginsOrder()
     }
 
@@ -382,11 +382,11 @@ export default class CanvasDrawer extends Mixin {
     const { width: canvasWidth, height: canvasHeight } = this.tokensLayer.getSize()
     const renderData = {
       context: this.frontLayer.context,
-      canvasWidth: canvasWidth,
-      canvasHeight: canvasHeight,
-      lineHeight: lineHeight,
-      charWidth: charWidth,
-      charHeight: charHeight,
+      canvasWidth,
+      canvasHeight,
+      lineHeight,
+      charWidth,
+      charHeight,
       orders: Main.getPluginsOrder()
     }
 

--- a/lib/mixins/decoration-management.js
+++ b/lib/mixins/decoration-management.js
@@ -356,9 +356,9 @@ export default class DecorationManagement {
             for (let i = 0, len = decorations.length; i < len; i++) {
               const decoration = decorations[i]
               this.emitter.emit('did-change-decoration', {
-                marker: marker,
-                decoration: decoration,
-                event: event
+                marker,
+                decoration,
+                event
               })
               this.emitDecorationChanges(decoration.type, decoration)
 
@@ -385,8 +385,8 @@ export default class DecorationManagement {
           for (let i = 0, len = rangesDiffs.length; i < len; i++) {
             const [start, end] = rangesDiffs[i]
             this.emitRangeChanges(type, {
-              start: start,
-              end: end
+              start,
+              end
             }, 0)
           }
         }))
@@ -415,8 +415,8 @@ export default class DecorationManagement {
 
     this.emitDecorationChanges(type, decoration)
     this.emitter.emit('did-add-decoration', {
-      marker: marker,
-      decoration: decoration
+      marker,
+      decoration
     })
 
     return decoration
@@ -503,8 +503,8 @@ export default class DecorationManagement {
     const changeEvent = {
       start: startScreenRow,
       end: endScreenRow,
-      screenDelta: screenDelta,
-      type: type
+      screenDelta,
+      type
     }
 
     this.emitter.emit('did-change-decoration-range', changeEvent)
@@ -544,8 +544,8 @@ export default class DecorationManagement {
       decorations.splice(index, 1)
 
       this.emitter.emit('did-remove-decoration', {
-        marker: marker,
-        decoration: decoration
+        marker,
+        decoration
       })
 
       if (decorations.length === 0) {
@@ -574,8 +574,8 @@ export default class DecorationManagement {
         this.emitDecorationChanges(decoration.getProperties().type, decoration)
       }
       this.emitter.emit('did-remove-decoration', {
-        marker: marker,
-        decoration: decoration
+        marker,
+        decoration
       })
     }
 

--- a/lib/mixins/decoration-management.js
+++ b/lib/mixins/decoration-management.js
@@ -233,7 +233,6 @@ export default class DecorationManagement {
 
     const decorations = this.decorationsById.values()
     for (const decoration of decorations) {
-
       const range = decoration.marker.getScreenRange()
       const type = decoration.getProperties().type
 
@@ -340,57 +339,57 @@ export default class DecorationManagement {
 
     if (!this.decorationMarkerDestroyedSubscriptions.has(id)) {
       this.decorationMarkerDestroyedSubscriptions.set(id,
-      marker.onDidDestroy(() => {
-        this.removeAllDecorationsForMarker(marker)
-      }))
+        marker.onDidDestroy(() => {
+          this.removeAllDecorationsForMarker(marker)
+        }))
     }
 
     if (!this.decorationMarkerChangedSubscriptions.has(id)) {
       this.decorationMarkerChangedSubscriptions.set(id,
-      marker.onDidChange((event) => {
-        const decorations = this.decorationsByMarkerId.get(id)
-        const screenRange = marker.getScreenRange()
+        marker.onDidChange((event) => {
+          const decorations = this.decorationsByMarkerId.get(id)
+          const screenRange = marker.getScreenRange()
 
-        this.invalidateDecorationForScreenRowsCache()
+          this.invalidateDecorationForScreenRowsCache()
 
-        if (decorations !== undefined) {
-          for (let i = 0, len = decorations.length; i < len; i++) {
-            const decoration = decorations[i]
-            this.emitter.emit('did-change-decoration', {
-              marker: marker,
-              decoration: decoration,
-              event: event
-            })
-            this.emitDecorationChanges(decoration.type, decoration)
+          if (decorations !== undefined) {
+            for (let i = 0, len = decorations.length; i < len; i++) {
+              const decoration = decorations[i]
+              this.emitter.emit('did-change-decoration', {
+                marker: marker,
+                decoration: decoration,
+                event: event
+              })
+              this.emitDecorationChanges(decoration.type, decoration)
 
-            decoration.screenRange = screenRange
+              decoration.screenRange = screenRange
+            }
           }
-        }
-        let oldStart = event.oldTailScreenPosition
-        let oldEnd = event.oldHeadScreenPosition
-        let newStart = event.newTailScreenPosition
-        let newEnd = event.newHeadScreenPosition
+          let oldStart = event.oldTailScreenPosition
+          let oldEnd = event.oldHeadScreenPosition
+          let newStart = event.newTailScreenPosition
+          let newEnd = event.newHeadScreenPosition
 
-        if (oldStart.row > oldEnd.row) {
-          [oldStart, oldEnd] = [oldEnd, oldStart]
-        }
-        if (newStart.row > newEnd.row) {
-          [newStart, newEnd] = [newEnd, newStart]
-        }
+          if (oldStart.row > oldEnd.row) {
+            [oldStart, oldEnd] = [oldEnd, oldStart]
+          }
+          if (newStart.row > newEnd.row) {
+            [newStart, newEnd] = [newEnd, newStart]
+          }
 
-        const rangesDiffs = this.computeRangesDiffs(
-          oldStart, oldEnd,
-          newStart, newEnd
-        )
+          const rangesDiffs = this.computeRangesDiffs(
+            oldStart, oldEnd,
+            newStart, newEnd
+          )
 
-        for (let i = 0, len = rangesDiffs.length; i < len; i++) {
-          const [start, end] = rangesDiffs[i]
-          this.emitRangeChanges(type, {
-            start: start,
-            end: end
-          }, 0)
-        }
-      }))
+          for (let i = 0, len = rangesDiffs.length; i < len; i++) {
+            const [start, end] = rangesDiffs[i]
+            this.emitRangeChanges(type, {
+              start: start,
+              end: end
+            }, 0)
+          }
+        }))
     }
 
     const decoration = new Decoration(marker, this, decorationParams)
@@ -404,15 +403,15 @@ export default class DecorationManagement {
 
     if (!this.decorationUpdatedSubscriptions.has(decoration.id)) {
       this.decorationUpdatedSubscriptions.set(decoration.id,
-      decoration.onDidChangeProperties((event) => {
-        this.emitDecorationChanges(type, decoration)
-      }))
+        decoration.onDidChangeProperties((event) => {
+          this.emitDecorationChanges(type, decoration)
+        }))
     }
 
     this.decorationDestroyedSubscriptions.set(decoration.id,
-    decoration.onDidDestroy(() => {
-      this.removeDecoration(decoration)
-    }))
+      decoration.onDidDestroy(() => {
+        this.removeDecoration(decoration)
+      }))
 
     this.emitDecorationChanges(type, decoration)
     this.emitter.emit('did-add-decoration', {

--- a/lib/plugin-management.js
+++ b/lib/plugin-management.js
@@ -59,7 +59,7 @@ export function registerPlugin (name, plugin) {
   plugins[name] = plugin
   pluginsSubscriptions[name] = new CompositeDisposable()
 
-  const event = { name: name, plugin: plugin }
+  const event = { name, plugin }
   emitter.emit('did-add-plugin', event)
 
   if (atom.config.get('minimap.displayPluginsControls')) {
@@ -85,7 +85,7 @@ export function unregisterPlugin (name) {
 
   delete plugins[name]
 
-  const event = { name: name, plugin: plugin }
+  const event = { name, plugin }
   emitter.emit('did-remove-plugin', event)
 }
 
@@ -120,7 +120,7 @@ export function togglePluginActivation (name, boolean) {
 export function deactivateAllPlugins () {
   for (const [name, plugin] of eachPlugin()) {
     plugin.deactivatePlugin()
-    emitter.emit('did-deactivate-plugin', { name: name, plugin: plugin })
+    emitter.emit('did-deactivate-plugin', { name, plugin })
   }
 }
 
@@ -165,14 +165,14 @@ function updatesPluginActivationState (name) {
 }
 
 export function activatePlugin (name, plugin) {
-  const event = { name: name, plugin: plugin }
+  const event = { name, plugin }
 
   plugin.activatePlugin()
   emitter.emit('did-activate-plugin', event)
 }
 
 export function deactivatePlugin (name, plugin) {
-  const event = { name: name, plugin: plugin }
+  const event = { name, plugin }
 
   plugin.deactivatePlugin()
   emitter.emit('did-deactivate-plugin', event)
@@ -226,7 +226,7 @@ function registerPluginControls (name, plugin) {
 
   pluginsSubscriptions[name].add(atom.config.observe(orderSettingsKey, (order) => {
     updatePluginsOrderMap(name)
-    const event = { name: name, plugin: plugin, order: order }
+    const event = { name, plugin, order }
     emitter.emit('did-change-plugin-order', event)
   }))
 

--- a/spec/minimap-element-spec.js
+++ b/spec/minimap-element-spec.js
@@ -751,8 +751,7 @@ describe('MinimapElement', () => {
             expect(editorElement.getScrollTop()).toBeNear(expectedScroll, 3)
           })
 
-          describe('dragging the visible area with middle mouse button ' +
-          'after scrolling to the arbitrary location', () => {
+          describe('dragging the visible area with middle mouse button after scrolling to the arbitrary location', () => {
             let [originalTop] = []
 
             beforeEach(() => {
@@ -769,8 +768,7 @@ describe('MinimapElement', () => {
               minimapElement.endDrag()
             })
 
-            it('scrolls the editor so that the visible area was moved down ' +
-            'by 40 pixels from the arbitrary location', () => {
+            it('scrolls the editor so that the visible area was moved down by 40 pixels from the arbitrary location', () => {
               const { top } = visibleArea.getBoundingClientRect()
               expect(top).toBeCloseTo(originalTop + 40, -1)
             })
@@ -1487,7 +1485,7 @@ describe('MinimapElement', () => {
 
           it('adjusts the width of the minimap', () => {
             expect(minimapElement.offsetWidth).toBeCloseTo(16384 * 2)
-            expect(minimapElement.style.width).toEqual(16384 * 2 + 'px')
+            expect(minimapElement.style.width).toEqual(`${16384 * 2}px`)
           })
         })
       })


### PR DESCRIPTION
This prevents defining temporary strings that should resize to get a final string value.

```
git clone https://github.com/cpojer/js-codemod.git
jscodeshift -t js-codemod/transforms/template-literals.js lib
jscodeshift -t js-codemod/transforms/template-literals.js spec
jscodeshift -t js-codemod/transforms/object-shorthand.js lib
jscodeshift -t js-codemod/transforms/object-shorthand.js spec
```