### PR TITLE
feat: warn about poor performance if treesitter is off

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -5,6 +5,7 @@ import MinimapElement from './minimap-element'
 import Minimap from './minimap'
 import config from './config.json'
 import * as PluginManagement from './plugin-management'
+import { treeSitterWarning } from './performance-monitor'
 
 export * as config from './config.json'
 export * from './plugin-management'
@@ -349,13 +350,16 @@ export function observeMinimaps (iterator) {
    * @access private
    */
 function initSubscriptions () {
-  subscriptions.add(atom.workspace.observeTextEditors((textEditor) => {
-    const minimap = minimapForEditor(textEditor)
-    const minimapElement = atom.views.getView(minimap)
+  subscriptions.add(
+    atom.workspace.observeTextEditors((textEditor) => {
+      const minimap = minimapForEditor(textEditor)
+      const minimapElement = atom.views.getView(minimap)
 
-    emitter.emit('did-create-minimap', minimap)
-    minimapElement.attach()
-  }))
+      emitter.emit('did-create-minimap', minimap)
+      minimapElement.attach()
+    }),
+    treeSitterWarning()
+  )
 }
 
 // The public exports included in the service:

--- a/lib/performance-monitor.js
+++ b/lib/performance-monitor.js
@@ -1,3 +1,14 @@
+// Functions used to recommend the configurations required for the best performance of Minimap
+
+export function treeSitterWarning () {
+  return observeAndWarn(
+    'core.useTreeSitterParsers',
+    true,
+    'Tree-sitter is off (Low Performance Warning).',
+    `You should turn on Atom's tree-sitter parser to experience the best performance Minimap and Atom is deisgned for.
+    Keeping tree-sitter parser off results in sluggish scrolling and lags in the text editor.`
+  )
+}
 
 /* Utility function that observes a config and throws warnings once a day if it is not the recommended value */
 function observeAndWarn (configName, recommendedValue, warningTitle, warningDescription) {

--- a/lib/performance-monitor.js
+++ b/lib/performance-monitor.js
@@ -1,0 +1,40 @@
+
+/* Utility function that observes a config and throws warnings once a day if it is not the recommended value */
+function observeAndWarn (configName, recommendedValue, warningTitle, warningDescription) {
+  return atom.config.observe(configName, value => {
+    if (value !== recommendedValue) {
+      const storageName = `Minimap.${configName}`
+      const today = new Date()
+      const previousWarning = window.localStorage.getItem(storageName)
+      let previousWarningDay = null
+      if (previousWarning) {
+        previousWarningDay = (new Date(Date.parse(previousWarning))).getDay()
+      }
+      // throw the warning once a day
+      if (!previousWarningDay ||
+        (typeof previousWarningDay === 'number' && (previousWarningDay - today.getDay() >= 1))
+      ) {
+        window.localStorage.setItem(storageName, today)
+
+        const notification = atom.notifications.addWarning(
+          warningTitle, {
+            description: warningDescription,
+            dismissable: true,
+            buttons: [
+              {
+                text: `Set to ${recommendedValue} and restart Atom`,
+                onDidClick () {
+                  atom.config.set(configName, true)
+                  notification.dismiss()
+                  window.localStorage.removeItem(storageName)
+                  setTimeout(() => {
+                    atom.reload()
+                  }, 1500)
+                }
+              }
+            ]
+          })
+      }
+    }
+  })
+}


### PR DESCRIPTION
The performance of Minimap with and without Tree-sitter is like night and day. We should inform the users about this, so they can have the best experience with Minimap.