### PR TITLE
Experiment: Use fillText

### DIFF
--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -447,30 +447,17 @@ const oneOrMoreWhiteSpaceRegexp = /\s+/
  */
 function drawToken (context, text, color, x, y, charWidth, charHeight, ignoreWhitespacesInTokens) {
   context.fillStyle = color
-
   if (ignoreWhitespacesInTokens) {
     const length = text.length * charWidth
     context.fillRect(x, y, length, charHeight)
-
     return x + length
   } else {
-    let chars = 0
-    for (let j = 0, len = text.length; j < len; j++) {
-      const char = text[j]
-      if (char === ' ') {
-        if (chars > 0) {
-          context.fillRect(x - (chars * charWidth), y, chars * charWidth, charHeight)
-        }
-        chars = 0
-      } else {
-        chars++
-      }
-      x += charWidth
-    }
-    if (chars > 0) {
-      context.fillRect(x - (chars * charWidth), y, chars * charWidth, charHeight)
-    }
-    return x
+    context.font = `3px sans-serif`;
+    context.textAlign = 'start'
+    context.testBaseline = 'top'
+    const length = text.length * charWidth
+    context.fillText(text, x, y + charHeight, length)
+    return x + length
   }
 }
 


### PR DESCRIPTION
This uses fillText instead of fillRect to render the exact text.
- [ ] The performance should be evaluated.
- [ ] minimap-titles should be updated (its rendering now looks a little different).


![image](https://user-images.githubusercontent.com/16418197/103957179-c6681000-510f-11eb-9f1d-c2acd887e970.png)

