### PR TITLE
fix: destructure renderData in decoration drawers

### DIFF
--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -592,8 +592,11 @@ const frontDecorationDispatcher = {
  * @access private
  */
 function drawLineDecoration (decoration, data, decorationColor) {
-  data.context.fillStyle = decorationColor
-  data.context.fillRect(0, data.yRow, data.canvasWidth, data.lineHeight)
+
+  const { context, lineHeight, canvasWidth, yRow } = data
+
+  context.fillStyle = decorationColor
+  context.fillRect(0, yRow, canvasWidth, lineHeight)
 }
 
 /**

--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -621,21 +621,24 @@ function drawGutterDecoration (decoration, data, decorationColor) {
  * @access private
  */
 function drawHighlightDecoration (decoration, data, decorationColor) {
+
+  const { context, lineHeight, charWidth, canvasWidth, screenRow, yRow } = data
+
   const range = decoration.getMarker().getScreenRange()
   const rowSpan = range.end.row - range.start.row
 
-  data.context.fillStyle = decorationColor
+  context.fillStyle = decorationColor
 
   if (rowSpan === 0) {
     const colSpan = range.end.column - range.start.column
-    data.context.fillRect(range.start.column * data.charWidth, data.yRow, colSpan * data.charWidth, data.lineHeight)
-  } else if (data.screenRow === range.start.row) {
-    const x = range.start.column * data.charWidth
-    data.context.fillRect(x, data.yRow, data.canvasWidth - x, data.lineHeight)
-  } else if (data.screenRow === range.end.row) {
-    data.context.fillRect(0, data.yRow, range.end.column * data.charWidth, data.lineHeight)
+    context.fillRect(range.start.column * charWidth, yRow, colSpan * charWidth, lineHeight)
+  } else if (screenRow === range.start.row) {
+    const x = range.start.column * charWidth
+    context.fillRect(x, yRow, canvasWidth - x, lineHeight)
+  } else if (screenRow === range.end.row) {
+    context.fillRect(0, yRow, range.end.column * charWidth, lineHeight)
   } else {
-    data.context.fillRect(0, data.yRow, data.canvasWidth, data.lineHeight)
+    context.fillRect(0, yRow, canvasWidth, lineHeight)
   }
 }
 

--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -592,7 +592,6 @@ const frontDecorationDispatcher = {
  * @access private
  */
 function drawLineDecoration (decoration, data, decorationColor) {
-
   const { context, lineHeight, canvasWidth, yRow } = data
 
   context.fillStyle = decorationColor
@@ -608,7 +607,6 @@ function drawLineDecoration (decoration, data, decorationColor) {
  * @access private
  */
 function drawGutterDecoration (decoration, data, decorationColor) {
-
   const { context, lineHeight, yRow } = data
 
   context.fillStyle = decorationColor
@@ -627,7 +625,6 @@ function drawGutterDecoration (decoration, data, decorationColor) {
  * @access private
  */
 function drawHighlightDecoration (decoration, data, decorationColor) {
-
   const { context, lineHeight, charWidth, canvasWidth, screenRow, yRow } = data
 
   const range = decoration.getMarker().getScreenRange()
@@ -660,7 +657,6 @@ function drawHighlightDecoration (decoration, data, decorationColor) {
  * @access private
  */
 function drawHighlightOutlineDecoration (decoration, data, decorationColor) {
-
   const { context, lineHeight, charWidth, canvasWidth, screenRow, yRow } = data
 
   let bottomWidth, colSpan, width, xBottomStart, xEnd, xStart

--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -651,14 +651,16 @@ function drawHighlightDecoration (decoration, data, decorationColor) {
  * @access private
  */
 function drawHighlightOutlineDecoration (decoration, data, decorationColor) {
+
+  const { context, lineHeight, charWidth, canvasWidth, screenRow, yRow } = data
+
   let bottomWidth, colSpan, width, xBottomStart, xEnd, xStart
-  const { lineHeight, charWidth, canvasWidth, screenRow } = data
   const range = decoration.getMarker().getScreenRange()
   const rowSpan = range.end.row - range.start.row
-  const yStart = data.yRow
+  const yStart = yRow
   const yEnd = yStart + lineHeight
 
-  data.context.fillStyle = decorationColor
+  context.fillStyle = decorationColor
 
   if (rowSpan === 0) {
     colSpan = range.end.column - range.start.column
@@ -666,31 +668,31 @@ function drawHighlightOutlineDecoration (decoration, data, decorationColor) {
     xStart = range.start.column * charWidth
     xEnd = xStart + width
 
-    data.context.fillRect(xStart, yStart, width, 1)
-    data.context.fillRect(xStart, yEnd - 1, width, 1)
-    data.context.fillRect(xStart, yStart, 1, lineHeight)
-    data.context.fillRect(xEnd, yStart, 1, lineHeight)
+    context.fillRect(xStart, yStart, width, 1)
+    context.fillRect(xStart, yEnd - 1, width, 1)
+    context.fillRect(xStart, yStart, 1, lineHeight)
+    context.fillRect(xEnd, yStart, 1, lineHeight)
   } else if (rowSpan === 1) {
-    xStart = range.start.column * data.charWidth
-    xEnd = range.end.column * data.charWidth
+    xStart = range.start.column * charWidth
+    xEnd = range.end.column * charWidth
 
     if (screenRow === range.start.row) {
-      width = data.canvasWidth - xStart
+      width = canvasWidth - xStart
       xBottomStart = Math.max(xStart, xEnd)
-      bottomWidth = data.canvasWidth - xBottomStart
+      bottomWidth = canvasWidth - xBottomStart
 
-      data.context.fillRect(xStart, yStart, width, 1)
-      data.context.fillRect(xBottomStart, yEnd - 1, bottomWidth, 1)
-      data.context.fillRect(xStart, yStart, 1, lineHeight)
-      data.context.fillRect(canvasWidth - 1, yStart, 1, lineHeight)
+      context.fillRect(xStart, yStart, width, 1)
+      context.fillRect(xBottomStart, yEnd - 1, bottomWidth, 1)
+      context.fillRect(xStart, yStart, 1, lineHeight)
+      context.fillRect(canvasWidth - 1, yStart, 1, lineHeight)
     } else {
       width = canvasWidth - xStart
       bottomWidth = canvasWidth - xEnd
 
-      data.context.fillRect(0, yStart, xStart, 1)
-      data.context.fillRect(0, yEnd - 1, xEnd, 1)
-      data.context.fillRect(0, yStart, 1, lineHeight)
-      data.context.fillRect(xEnd, yStart, 1, lineHeight)
+      context.fillRect(0, yStart, xStart, 1)
+      context.fillRect(0, yEnd - 1, xEnd, 1)
+      context.fillRect(0, yStart, 1, lineHeight)
+      context.fillRect(xEnd, yStart, 1, lineHeight)
     }
   } else {
     xStart = range.start.column * charWidth
@@ -698,23 +700,23 @@ function drawHighlightOutlineDecoration (decoration, data, decorationColor) {
     if (screenRow === range.start.row) {
       width = canvasWidth - xStart
 
-      data.context.fillRect(xStart, yStart, width, 1)
-      data.context.fillRect(xStart, yStart, 1, lineHeight)
-      data.context.fillRect(canvasWidth - 1, yStart, 1, lineHeight)
+      context.fillRect(xStart, yStart, width, 1)
+      context.fillRect(xStart, yStart, 1, lineHeight)
+      context.fillRect(canvasWidth - 1, yStart, 1, lineHeight)
     } else if (screenRow === range.end.row) {
       width = canvasWidth - xStart
 
-      data.context.fillRect(0, yEnd - 1, xEnd, 1)
-      data.context.fillRect(0, yStart, 1, lineHeight)
-      data.context.fillRect(xEnd, yStart, 1, lineHeight)
+      context.fillRect(0, yEnd - 1, xEnd, 1)
+      context.fillRect(0, yStart, 1, lineHeight)
+      context.fillRect(xEnd, yStart, 1, lineHeight)
     } else {
-      data.context.fillRect(0, yStart, 1, lineHeight)
-      data.context.fillRect(canvasWidth - 1, yStart, 1, lineHeight)
+      context.fillRect(0, yStart, 1, lineHeight)
+      context.fillRect(canvasWidth - 1, yStart, 1, lineHeight)
       if (screenRow === range.start.row + 1) {
-        data.context.fillRect(0, yStart, xStart, 1)
+        context.fillRect(0, yStart, xStart, 1)
       }
       if (screenRow === range.end.row - 1) {
-        data.context.fillRect(xEnd, yEnd - 1, canvasWidth - xEnd, 1)
+        context.fillRect(xEnd, yEnd - 1, canvasWidth - xEnd, 1)
       }
     }
   }

--- a/lib/mixins/canvas-drawer.js
+++ b/lib/mixins/canvas-drawer.js
@@ -605,8 +605,11 @@ function drawLineDecoration (decoration, data, decorationColor) {
  * @access private
  */
 function drawGutterDecoration (decoration, data, decorationColor) {
-  data.context.fillStyle = decorationColor
-  data.context.fillRect(0, data.yRow, 1, data.lineHeight)
+
+  const { context, lineHeight, yRow } = data
+
+  context.fillStyle = decorationColor
+  context.fillRect(0, yRow, 1, lineHeight)
 }
 
 /**


### PR DESCRIPTION
Use property destructure instead of property accessing in decorations drawers. This allows eventually removing the need for passing an object (renderData) in later PRs.