### PR TITLE
fix: toggle null-bugs

### DIFF
--- a/lib/decoration-management.js
+++ b/lib/decoration-management.js
@@ -603,6 +603,13 @@ export default class DecorationManagement {
     this.decorationUpdatedSubscriptions.clear()
     this.decorationDestroyedSubscriptions.clear()
   }
+
+  destroy() {
+    this.removeAllDecorations()
+    this.minimap = undefined
+    this.emitter = undefined
+    this.destroyed = true
+  }
 }
 
 function getOriginatorPackageName () {

--- a/lib/decoration-management.js
+++ b/lib/decoration-management.js
@@ -604,7 +604,7 @@ export default class DecorationManagement {
     this.decorationDestroyedSubscriptions.clear()
   }
 
-  destroy() {
+  destroy () {
     this.removeAllDecorations()
     this.minimap = undefined
     this.emitter = undefined

--- a/lib/main.js
+++ b/lib/main.js
@@ -303,8 +303,7 @@ export function minimapForEditor (textEditor) {
     editorsMinimaps.set(textEditor, minimap)
 
     const editorSubscription = textEditor.onDidDestroy(() => {
-      const minimaps = editorsMinimaps
-      if (minimaps) { minimaps.delete(textEditor) }
+      if (editorsMinimaps) { editorsMinimaps.delete(textEditor) }
       editorSubscription.dispose()
     })
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -364,7 +364,7 @@ function initSubscriptions () {
       const minimapElement = minimap.getMinimapElement() || atom.views.getView(minimap)
 
       emitter.emit('did-create-minimap', minimap)
-      minimapElement.attach()
+      minimapElement.attach(textEditor.getElement())
     }),
     // empty color cache if the theme changes
     atom.themes.onDidChangeActiveThemes(() => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -362,7 +362,7 @@ function initSubscriptions () {
   subscriptions.add(
     atom.workspace.observeTextEditors((textEditor) => {
       const minimap = minimapForEditor(textEditor)
-      const minimapElement = minimap.getMinimapElement() || atom.views.getView(minimap)
+      const minimapElement = minimap.getMinimapElement() || minimapViewProvider(minimap)
 
       emitter.emit('did-create-minimap', minimap)
       minimapElement.attach(textEditor.getElement())

--- a/lib/main.js
+++ b/lib/main.js
@@ -152,8 +152,8 @@ export function toggle () {
     toggled = false
 
     if (editorsMinimaps) {
-      editorsMinimaps.forEach((value, key) => {
-        value.destroy()
+      editorsMinimaps.forEach((minimap, key) => {
+        minimap.destroy()
         editorsMinimaps.delete(key)
       })
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -297,7 +297,8 @@ export function minimapForEditor (textEditor) {
   if (!editorsMinimaps) { return }
 
   let minimap = editorsMinimaps.get(textEditor)
-  if (minimap === undefined) {
+
+  if (minimap === undefined || minimap.destroyed) {
     minimap = new Minimap({ textEditor })
     editorsMinimaps.set(textEditor, minimap)
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -158,6 +158,15 @@ export function toggle () {
       editorsMinimaps.clear()
     }
     subscriptions.dispose()
+
+    // HACK: this hack forces rerendering editor size which moves the scrollbar to the right once minimap is removed
+    const wasMaximized = atom.isMaximized()
+    const { width, height } = atom.getSize()
+    atom.setSize(width, height)
+    if (wasMaximized) {
+      atom.maximize()
+    }
+
   } else {
     toggled = true
     initSubscriptions()

--- a/lib/main.js
+++ b/lib/main.js
@@ -122,10 +122,10 @@ export function deactivate () {
   PluginManagement.deactivateAllPlugins()
 
   if (editorsMinimaps) {
-    editorsMinimaps.forEach((value, key) => {
+    editorsMinimaps.forEach((value) => {
       value.destroy()
-      editorsMinimaps.delete(key)
     })
+    editorsMinimaps.clear()
   }
 
   subscriptions.dispose()
@@ -152,10 +152,10 @@ export function toggle () {
     toggled = false
 
     if (editorsMinimaps) {
-      editorsMinimaps.forEach((minimap, key) => {
+      editorsMinimaps.forEach((minimap) => {
         minimap.destroy()
-        editorsMinimaps.delete(key)
       })
+      editorsMinimaps.clear()
     }
     subscriptions.dispose()
   } else {

--- a/lib/main.js
+++ b/lib/main.js
@@ -362,7 +362,7 @@ function initSubscriptions () {
   subscriptions.add(
     atom.workspace.observeTextEditors((textEditor) => {
       const minimap = minimapForEditor(textEditor)
-      const minimapElement = atom.views.getView(minimap)
+      const minimapElement = minimap.getMinimapElement() || atom.views.getView(minimap)
 
       emitter.emit('did-create-minimap', minimap)
       minimapElement.attach()

--- a/lib/main.js
+++ b/lib/main.js
@@ -297,8 +297,7 @@ export function minimapForEditor (textEditor) {
   if (!editorsMinimaps) { return }
 
   let minimap = editorsMinimaps.get(textEditor)
-
-  if (!minimap) {
+  if (minimap === undefined) {
     minimap = new Minimap({ textEditor })
     editorsMinimaps.set(textEditor, minimap)
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -40,7 +40,7 @@ let toggled = false
      * @type {Map}
      * @access private
      */
-let editorsMinimaps = null
+export let editorsMinimaps = null
 /**
      * The composite disposable that stores the package's subscriptions.
      *

--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -454,8 +454,11 @@ class MinimapElement {
    * Destroys this MinimapElement
    */
   destroy () {
-    this.subscriptions.dispose()
     this.DecorationManagement.destroy()
+    if (this.quickSettingsElement) {
+      this.quickSettingsElement.destroy()
+    }
+    this.subscriptions.dispose()
     this.detach()
     if (this.minimap) {
       this.minimap.minimapElement = null

--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -427,7 +427,10 @@ class MinimapElement {
     const container = parent || this.minimap.getTextEditorElement()
     const minimaps = container.querySelectorAll('atom-text-editor-minimap')
     if (minimaps.length) {
-      Array.prototype.forEach.call(minimaps, (el) => { el.destroy() })
+      Array.prototype.forEach.call(minimaps, (el) => {
+        el.destroy()
+        container.removeChild(el)
+      })
     }
     container.appendChild(this)
   }

--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -455,8 +455,7 @@ class MinimapElement {
    */
   destroy () {
     this.subscriptions.dispose()
-    this.DecorationManagement.removeAllDecorations()
-    this.DecorationManagement.destroyed = true
+    this.DecorationManagement.destroy()
     this.detach()
     this.minimap.minimapElement = null
     this.minimap = null

--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -457,8 +457,10 @@ class MinimapElement {
     this.subscriptions.dispose()
     this.DecorationManagement.destroy()
     this.detach()
-    this.minimap.minimapElement = null
-    this.minimap = null
+    if (this.minimap) {
+      this.minimap.minimapElement = null
+      this.minimap = null
+    }
   }
 
   //     ######   #######  ##    ## ######## ######## ##    ## ########

--- a/lib/minimap-quick-settings-element.js
+++ b/lib/minimap-quick-settings-element.js
@@ -44,111 +44,114 @@ class MinimapQuickSettingsElement {
     this.plugins = {}
     this.itemsActions = new WeakMap()
 
-    const subs = this.subscriptions
-
-    subs.add(Main.onDidAddPlugin(({ name, plugin }) => {
-      return this.addItemFor(name, plugin)
-    }))
-    subs.add(Main.onDidRemovePlugin(({ name, plugin }) => {
-      return this.removeItemFor(name, plugin)
-    }))
-    subs.add(Main.onDidActivatePlugin(({ name, plugin }) => {
-      return this.activateItem(name, plugin)
-    }))
-    subs.add(Main.onDidDeactivatePlugin(({ name, plugin }) => {
-      return this.deactivateItem(name, plugin)
-    }))
-
-    subs.add(atom.commands.add('minimap-quick-settings', {
-      'core:move-up': () => {
-        this.selectPreviousItem()
-      },
-      'core:move-down': () => {
-        this.selectNextItem()
-      },
-      'core:move-left': () => {
-        atom.config.set('minimap.displayMinimapOnLeft', true)
-      },
-      'core:move-right': () => {
-        atom.config.set('minimap.displayMinimapOnLeft', false)
-      },
-      'core:cancel': () => {
-        this.destroy()
-      },
-      'core:confirm': () => {
-        this.toggleSelectedItem()
-      }
-    }))
-
     this.codeHighlights.classList.toggle('active', this.minimap.displayCodeHighlights)
-
-    subs.add(this.subscribeTo(this.codeHighlights, {
-      mousedown: (e) => {
-        e.preventDefault()
-        atom.config.set('minimap.displayCodeHighlights', !this.minimap.displayCodeHighlights)
-      }
-    }))
 
     this.itemsActions.set(this.codeHighlights, () => {
       atom.config.set('minimap.displayCodeHighlights', !this.minimap.displayCodeHighlights)
     })
 
-    subs.add(this.subscribeTo(this.absoluteMode, {
-      mousedown: (e) => {
-        e.preventDefault()
-        atom.config.set('minimap.absoluteMode', !atom.config.get('minimap.absoluteMode'))
-      }
-    }))
-
     this.itemsActions.set(this.absoluteMode, () => {
       atom.config.set('minimap.absoluteMode', !atom.config.get('minimap.absoluteMode'))
     })
-
-    subs.add(this.subscribeTo(this.adjustAbsoluteModeHeight, {
-      mousedown: (e) => {
-        e.preventDefault()
-        atom.config.set('minimap.adjustAbsoluteModeHeight', !atom.config.get('minimap.adjustAbsoluteModeHeight'))
-      }
-    }))
 
     this.itemsActions.set(this.adjustAbsoluteModeHeight, () => {
       atom.config.set('minimap.adjustAbsoluteModeHeight', !atom.config.get('minimap.adjustAbsoluteModeHeight'))
     })
 
-    subs.add(this.subscribeTo(this.hiddenInput, {
-      focusout: (e) => { this.destroy() }
-    }, { passive: true }))
+    this.subscriptions.add(
 
-    subs.add(this.subscribeTo(this.onLeftButton, {
-      mousedown: (e) => {
-        e.preventDefault()
-        atom.config.set('minimap.displayMinimapOnLeft', true)
-      }
-    }))
+      Main.onDidAddPlugin(({ name, plugin }) => {
+        return this.addItemFor(name, plugin)
+      }),
+      Main.onDidRemovePlugin(({ name, plugin }) => {
+        return this.removeItemFor(name, plugin)
+      }),
+      Main.onDidActivatePlugin(({ name, plugin }) => {
+        return this.activateItem(name, plugin)
+      }),
+      Main.onDidDeactivatePlugin(({ name, plugin }) => {
+        return this.deactivateItem(name, plugin)
+      }),
 
-    subs.add(this.subscribeTo(this.onRightButton, {
-      mousedown: (e) => {
-        e.preventDefault()
-        atom.config.set('minimap.displayMinimapOnLeft', false)
-      }
-    }))
+      atom.commands.add('minimap-quick-settings', {
+        'core:move-up': () => {
+          this.selectPreviousItem()
+        },
+        'core:move-down': () => {
+          this.selectNextItem()
+        },
+        'core:move-left': () => {
+          atom.config.set('minimap.displayMinimapOnLeft', true)
+        },
+        'core:move-right': () => {
+          atom.config.set('minimap.displayMinimapOnLeft', false)
+        },
+        'core:cancel': () => {
+          this.destroy()
+        },
+        'core:confirm': () => {
+          this.toggleSelectedItem()
+        }
+      }),
 
-    subs.add(atom.config.observe('minimap.displayCodeHighlights', (bool) => {
-      this.codeHighlights.classList.toggle('active', bool)
-    }))
+      this.subscribeTo(this.codeHighlights, {
+        mousedown: (e) => {
+          e.preventDefault()
+          atom.config.set('minimap.displayCodeHighlights', !this.minimap.displayCodeHighlights)
+        }
+      }),
 
-    subs.add(atom.config.observe('minimap.absoluteMode', (bool) => {
-      this.absoluteMode.classList.toggle('active', bool)
-    }))
+      this.subscribeTo(this.absoluteMode, {
+        mousedown: (e) => {
+          e.preventDefault()
+          atom.config.set('minimap.absoluteMode', !atom.config.get('minimap.absoluteMode'))
+        }
+      }),
 
-    subs.add(atom.config.observe('minimap.adjustAbsoluteModeHeight', (bool) => {
-      this.adjustAbsoluteModeHeight.classList.toggle('active', bool)
-    }))
+      this.subscribeTo(this.adjustAbsoluteModeHeight, {
+        mousedown: (e) => {
+          e.preventDefault()
+          atom.config.set('minimap.adjustAbsoluteModeHeight', !atom.config.get('minimap.adjustAbsoluteModeHeight'))
+        }
+      }),
 
-    subs.add(atom.config.observe('minimap.displayMinimapOnLeft', (bool) => {
-      this.onLeftButton.classList.toggle('selected', bool)
-      this.onRightButton.classList.toggle('selected', !bool)
-    }))
+      this.subscribeTo(this.hiddenInput, {
+        focusout: (e) => { this.destroy() }
+      },
+      { passive: true }
+      ),
+
+      this.subscribeTo(this.onLeftButton, {
+        mousedown: (e) => {
+          e.preventDefault()
+          atom.config.set('minimap.displayMinimapOnLeft', true)
+        }
+      }),
+
+      this.subscribeTo(this.onRightButton, {
+        mousedown: (e) => {
+          e.preventDefault()
+          atom.config.set('minimap.displayMinimapOnLeft', false)
+        }
+      }),
+
+      atom.config.observe('minimap.displayCodeHighlights', (bool) => {
+        this.codeHighlights.classList.toggle('active', bool)
+      }),
+
+      atom.config.observe('minimap.absoluteMode', (bool) => {
+        this.absoluteMode.classList.toggle('active', bool)
+      }),
+
+      atom.config.observe('minimap.adjustAbsoluteModeHeight', (bool) => {
+        this.adjustAbsoluteModeHeight.classList.toggle('active', bool)
+      }),
+
+      atom.config.observe('minimap.displayMinimapOnLeft', (bool) => {
+        this.onLeftButton.classList.toggle('selected', bool)
+        this.onRightButton.classList.toggle('selected', !bool)
+      })
+    )
 
     this.initList()
   }

--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -270,7 +270,7 @@ export default class Minimap {
 
       this.textEditor.onDidDestroy(() => {
         if (editorsMinimaps) {
-          editorsMinimaps.delete(this.textEditor)         
+          editorsMinimaps.delete(this.textEditor)
         }
         this.destroy()
       }),

--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -2,6 +2,7 @@
 
 import { Emitter, CompositeDisposable } from 'atom'
 import StableAdapter from './adapters/stable-adapter'
+import { editorsMinimaps } from './main'
 
 let nextModelId = 1
 
@@ -268,7 +269,10 @@ export default class Minimap {
         this.scheduleChanges(changes)
       }),
 
-      this.textEditor.onDidDestroy(() => { this.destroy() }),
+      this.textEditor.onDidDestroy(() => {
+        editorsMinimaps.delete(this.textEditor)
+        this.destroy()
+      }),
 
       /*
       FIXME Some changes occuring during the tokenization produces

--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -269,7 +269,9 @@ export default class Minimap {
       }),
 
       this.textEditor.onDidDestroy(() => {
-        editorsMinimaps.delete(this.textEditor)
+        if (editorsMinimaps) {
+          editorsMinimaps.delete(this.textEditor)         
+        }
         this.destroy()
       }),
 

--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -469,46 +469,55 @@ export default class Minimap {
     const subs = new CompositeDisposable()
     const opts = { scope: this.textEditor.getRootScopeDescriptor() }
 
-    subs.add(atom.config.observe('editor.scrollPastEnd', opts, (scrollPastEnd) => {
-      this.scrollPastEnd = scrollPastEnd
-      this.adapter.scrollPastEnd = this.scrollPastEnd
-      this.emitter.emit('did-change-config')
-    }))
-    subs.add(atom.config.observe('minimap.charHeight', opts, (configCharHeight) => {
-      this.configCharHeight = configCharHeight
-      this.updateScrollTop()
-      this.emitter.emit('did-change-config')
-    }))
-    subs.add(atom.config.observe('minimap.charWidth', opts, (configCharWidth) => {
-      this.configCharWidth = configCharWidth
-      this.updateScrollTop()
-      this.emitter.emit('did-change-config')
-    }))
-    subs.add(atom.config.observe('minimap.interline', opts, (configInterline) => {
-      this.configInterline = configInterline
-      this.updateScrollTop()
-      this.emitter.emit('did-change-config')
-    }))
-    subs.add(atom.config.observe('minimap.independentMinimapScroll', opts, (independentMinimapScroll) => {
-      this.independentMinimapScroll = independentMinimapScroll
-      this.updateScrollTop()
-    }))
-    subs.add(atom.config.observe('minimap.scrollSensitivity', opts, (scrollSensitivity) => {
-      this.scrollSensitivity = scrollSensitivity
-    }))
-    subs.add(atom.config.observe('minimap.redrawDelay', opts, (redrawDelay) => {
-      this.redrawDelay = redrawDelay
-    }))
-    // cdprr is shorthand for configDevicePixelRatioRounding
-    subs.add(atom.config.observe(
-      'minimap.devicePixelRatioRounding',
-      opts,
-      (cdprr) => {
-        this.configDevicePixelRatioRounding = cdprr
+    subs.add(
+      atom.config.observe('editor.scrollPastEnd', opts, (scrollPastEnd) => {
+        this.scrollPastEnd = scrollPastEnd
+        this.adapter.scrollPastEnd = this.scrollPastEnd
+        this.emitter.emit('did-change-config')
+      }),
+
+      atom.config.observe('minimap.charHeight', opts, (configCharHeight) => {
+        this.configCharHeight = configCharHeight
         this.updateScrollTop()
         this.emitter.emit('did-change-config')
-      }
-    ))
+      }),
+
+      atom.config.observe('minimap.charWidth', opts, (configCharWidth) => {
+        this.configCharWidth = configCharWidth
+        this.updateScrollTop()
+        this.emitter.emit('did-change-config')
+      }),
+
+      atom.config.observe('minimap.interline', opts, (configInterline) => {
+        this.configInterline = configInterline
+        this.updateScrollTop()
+        this.emitter.emit('did-change-config')
+      }),
+
+      atom.config.observe('minimap.independentMinimapScroll', opts, (independentMinimapScroll) => {
+        this.independentMinimapScroll = independentMinimapScroll
+        this.updateScrollTop()
+      }),
+
+      atom.config.observe('minimap.scrollSensitivity', opts, (scrollSensitivity) => {
+        this.scrollSensitivity = scrollSensitivity
+      }),
+
+      atom.config.observe('minimap.redrawDelay', opts, (redrawDelay) => {
+        this.redrawDelay = redrawDelay
+      }),
+      // cdprr is shorthand for configDevicePixelRatioRounding
+
+      atom.config.observe(
+        'minimap.devicePixelRatioRounding',
+        opts,
+        (cdprr) => {
+          this.configDevicePixelRatioRounding = cdprr
+          this.updateScrollTop()
+          this.emitter.emit('did-change-config')
+        }
+      )
+    )
 
     return subs
   }

--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -232,18 +232,17 @@ export default class Minimap {
      */
     this.scrollTop = 0
 
-    const subs = this.subscriptions
     let configSubscription = this.subscribeToConfig()
 
-    subs.add(
+    this.subscriptions.add(
       configSubscription,
 
       this.textEditor.onDidChangeGrammar(() => {
-        subs.remove(configSubscription)
+        this.subscriptions.remove(configSubscription)
         configSubscription.dispose()
 
         configSubscription = this.subscribeToConfig()
-        subs.add(configSubscription)
+        this.subscriptions.add(configSubscription)
       }),
 
       this.adapter.onDidChangeScrollTop(() => {


### PR DESCRIPTION
- When minimap is toggled on/off and editors are closed/open, some null bugs may appear.
- The minimaps were not destroyed correctly
- hack for forcing scroller movement once minimap is toggled off

Fixes https://github.com/atom-minimap/minimap/issues/764
Fixes https://github.com/atom-minimap/minimap/issues/763