### PR TITLE
fix: do not null set the values in destroy

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -135,10 +135,7 @@ export function deactivate() {
   }
 
   subscriptions.dispose()
-  subscriptions = null
   subscriptionsOfCommands.dispose()
-  subscriptionsOfCommands = null
-  editorsMinimaps = undefined
   domStylesReader.invalidateDOMStylesCache()
   toggled = false
   active = false

--- a/lib/minimap-element.js
+++ b/lib/minimap-element.js
@@ -506,10 +506,6 @@ class MinimapElement {
     }
     this.subscriptions.dispose()
     this.detach()
-    if (this.minimap) {
-      this.minimap.minimapElement = null
-      this.minimap = null
-    }
   }
 
   //     ######   #######  ##    ## ######## ######## ##    ## ########

--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -299,11 +299,8 @@ export default class Minimap {
     }
 
     clearTimeout(this.flushChangesTimer)
-    this.flushChangesTimer = null
     this.pendingChangeEvents = []
     this.subscriptions.dispose()
-    this.subscriptions = null
-    this.textEditor = null
     this.emitter.emit("did-destroy")
     this.emitter.dispose()
     this.destroyed = true

--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -1112,11 +1112,18 @@ export default class Minimap {
    * @return {DecorationManagement}
    */
   getDecorationManagement() {
-    if (
-      this.DecorationManagement === undefined &&
-      this.minimapElement // TODO: find why this becomes null: https://github.com/atom-minimap/minimap/issues/766
-    ) {
-      this.DecorationManagement = this.minimapElement.DecorationManagement
+    if (!this.DecorationManagement) {
+      if (this.minimapElement) {
+        this.DecorationManagement = this.minimapElement.DecorationManagement
+      } else {
+        // TODO: find why this becomes null: https://github.com/atom-minimap/minimap/issues/766
+        throw new Error(`getDecorationManagement failed.
+       this.DecorationManagement: ${JSON.stringify(this.DecorationManagement)}
+       this.minimapElement: ${JSON.stringify(this.minimapElement)}
+       this.textEditor: ${this.getTextEditor()}
+       this: ${JSON.stringify(this)}
+     `)
+      }
     }
     return this.DecorationManagement
   }

--- a/spec/minimap-main-spec.js
+++ b/spec/minimap-main-spec.js
@@ -113,7 +113,7 @@ describe("Minimap package", () => {
     })
 
     it("destroys all the minimap models", () => {
-      expect(minimapPackage.editorsMinimaps).toBeUndefined()
+      expect(minimapPackage.editorsMinimaps.size).toBe(0)
     })
 
     it("destroys all the minimap elements", () => {


### PR DESCRIPTION
Do not null set the properties manually. JavaScript's garbage collector is smart enough to collect the unreferenced destroyed variables.

Fixes #778

