### PR TITLE
fix: remove preventDefault from onMouseWheel for independent scroll

### DIFF
--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -1038,7 +1038,6 @@ export default class Minimap {
       const previousScrollTop = this.getScrollTop()
       const updatedScrollTop = previousScrollTop - Math.round(wheelDeltaY * this.scrollSensitivity)
 
-      event.preventDefault()
       this.setScrollTop(updatedScrollTop)
     }
   }


### PR DESCRIPTION
Because `onMouseWheel` is a passive event listener we should not call `preventDefault`. Without this change, the code actually throws an exception!

## Test procedure
 I have tested the functionality without this code and it works as expected.
Enable independent scroll on minimap and try to scroll your mouse wheel while hovering on Minimap

![independent-scroll](https://user-images.githubusercontent.com/16418197/113386072-0590b080-934f-11eb-95d9-5f35e8c8cd85.gif)
