### PR TITLE
fix: rotateHue accepts negative hue values in DOMStylesReader

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,20 +53,14 @@ jobs:
       - name: Commit lint ✨
         uses: wagoid/commitlint-github-action@v2
 
-      - uses: UziTech/action-setup-atom@v1
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v1.2.1
-        with:
-          version: latest
-
       - name: Install dependencies
-        run: pnpm install
+        run: npm install
 
       - name: Format ✨
-        run: pnpm test.format
+        run: npm run test.format
 
       - name: Lint ✨
-        run: pnpm test.lint
+        run: npm run test.lint
 
   Release:
     needs: [Test, Lint]

--- a/lib/dom-styles-reader.js
+++ b/lib/dom-styles-reader.js
@@ -148,7 +148,7 @@ export default class DOMStylesReader {
 
 const dotRegexp = /\.+/g
 const rgbExtractRegexp = /rgb(a?)\((\d+), (\d+), (\d+)(, (\d+(\.\d+)?))?\)/
-const hueRegexp = /hue-rotate\((\d+)deg\)/
+const hueRegexp = /hue-rotate\((-?\d+)deg\)/
 
 /**
  * Computes the output color of `value` with a rotated hue defined


### PR DESCRIPTION
Just a minor regexp fix in hueRegexp.

Issue: Uncaught TypeError: Cannot read property 'Symbol(Symbol.iterator)' of filter.match #671 