### PR TITLE
fix(lib.minimap):  scroll by drag if scrollPastEnd

### DIFF
--- a/lib/minimap.js
+++ b/lib/minimap.js
@@ -647,7 +647,8 @@ export default class Minimap {
    * @returns {number} The height of the minimap
    */
   getHeight() {
-    return this.textEditor.getScreenLineCount() * this.getLineHeight()
+    const additionalHeight = this.scrollPastEnd ? this.textEditor.getRowsPerPage() : 0
+    return (this.textEditor.getScreenLineCount() + additionalHeight) * this.getLineHeight()
   }
 
   /**


### PR DESCRIPTION
Previously there was problem if scroll past end enabled.

No scroll past end - all is well.
Enabled - there's some offset between mouse on screen on minimap and actual screen.
Screencast: https://youtu.be/zfAk14_9CEQ

This should fix it.

I checked by console.log when scrolling, mouse position was bigger when scrolling to bottom then height of minimap.
So it didn't account space added if scroll past end enabled.
"Minimap.getHeight" should return total height of minimap (is this true ?) (I read it in method description), so this PR also accounts space after last line added if scroll past end enabled.